### PR TITLE
fix(ios): fix gpu memory allocation during export

### DIFF
--- a/ios/VideoCompositionExporter.mm
+++ b/ios/VideoCompositionExporter.mm
@@ -172,7 +172,7 @@ void RNSkiaVideo::exportVideoComposition(
     id<MTLTexture> cpuAccessibleTexture =
         [device newTextureWithDescriptor:descriptor];
 
-    id<MTLCommandBuffer> commandBuffer = [commandQueue commandBuffer];
+    id<MTLCommandBuffer> commandBuffer = [commandQueue commandBufferWithUnretainedReferences];
     id<MTLBlitCommandEncoder> blitEncoder = [commandBuffer blitCommandEncoder];
     [blitEncoder
           copyFromTexture:mlTexture


### PR DESCRIPTION
Before
<img width="1002" alt="스크린샷 2024-08-27 오후 1 13 33" src="https://github.com/user-attachments/assets/76de1cc0-66eb-4c4b-88bd-def978928f96">

If the video duration longer, it will be crashed by OOM.

After with Unretained
<img width="1001" alt="스크린샷 2024-08-27 오후 1 16 25" src="https://github.com/user-attachments/assets/a3f3a898-e588-4bf7-bb9a-c8c7f17b0ca1">

