### PR TITLE
fix(ios): prevent initialize all decoder at once

### DIFF
--- a/ios/VideoCompositionExporter.h
+++ b/ios/VideoCompositionExporter.h
@@ -1,7 +1,7 @@
 #pragma once
 #import "VideoComposition.h"
 #include <RNSkPlatformContext.h>
-#include <WorkletRuntime.h>
+#include "WorkletRuntime.h"
 
 namespace RNSkiaVideo {
 using namespace facebook;

--- a/ios/VideoCompositionFramesExtractorHostObject.mm
+++ b/ios/VideoCompositionFramesExtractorHostObject.mm
@@ -43,6 +43,7 @@ VideoCompositionFramesExtractorHostObject::
                 return;
               }
             }
+            decoderPool(composition, itemDecoders, currentFrames, currentTime, true);
             for (const auto& entry : itemDecoders) {
               auto decoder = entry.second;
               if (decoder) {
@@ -215,10 +216,7 @@ void VideoCompositionFramesExtractorHostObject::init() {
       return;
     }
     try {
-      for (const auto& item : composition->items) {
-        itemDecoders[item->id] =
-            std::make_shared<VideoCompositionItemDecoder>(item, true);
-      }
+      decoderPool(composition, itemDecoders, currentFrames, kCMTimeZero, true);
     } catch (NSError* error) {
       itemDecoders.clear();
       emit("error", [=](jsi::Runtime& runtime) -> jsi::Value {

--- a/ios/VideoCompositionItemDecoder.h
+++ b/ios/VideoCompositionItemDecoder.h
@@ -4,6 +4,7 @@
 #import "VideoFrame.h"
 #import <AVFoundation/AVFoundation.h>
 #import <list>
+#import <map>
 
 using namespace facebook;
 
@@ -37,5 +38,35 @@ private:
 
   void setupReader(CMTime initialTime);
 };
+
+static void decoderPool(
+  std::shared_ptr<VideoComposition>& composition,
+  std::map<std::string, std::shared_ptr<VideoCompositionItemDecoder>>& itemDecoders,
+  std::map<std::string, std::shared_ptr<VideoFrame>>& currentFrames,
+  CMTime time,
+  bool realTime) {
+  for (const auto& item : composition->items) {
+    CMTime threshold = CMTimeMakeWithSeconds(0.5, NSEC_PER_SEC);
+    CMTime startTime = CMTimeMakeWithSeconds(item->startTime, NSEC_PER_SEC);
+    CMTime compositionStartTime = CMTimeMakeWithSeconds(item->compositionStartTime, NSEC_PER_SEC);
+    CMTime duration = CMTimeMakeWithSeconds(item->duration, NSEC_PER_SEC);
+    CMTime position = CMTimeAdd(startTime, CMTimeSubtract(time, compositionStartTime));
+    CMTime endTime = CMTimeAdd(startTime, duration);
+    
+    bool visible = (CMTimeCompare(CMTimeSubtract(startTime, threshold), position) <= 0 &&
+                    CMTimeCompare(CMTimeAdd(endTime, threshold), position) >= 0);
+    bool initialized = itemDecoders.count(item->id) > 0;
+    if (visible && !initialized) {
+      itemDecoders[item->id] = std::make_shared<VideoCompositionItemDecoder>(item, realTime);
+    } else if (!visible && initialized) {
+      itemDecoders[item->id]->release();
+      itemDecoders.erase(item->id);
+      if (currentFrames.count(item->id) > 0) {
+        currentFrames[item->id]->release();
+        currentFrames.erase(item->id);
+      }
+    }
+  }
+}
 
 } // namespace RNSkiaVideo

--- a/ios/VideoFrame.mm
+++ b/ios/VideoFrame.mm
@@ -51,10 +51,11 @@ jsi::Value VideoFrame::get(jsi::Runtime& runtime,
 }
 
 void VideoFrame::release() {
-  if (released.test_and_set()) {
-    return;
+  if (!released.test_and_set()) {
+    if (pixelBuffer) {
+      CVPixelBufferRelease(pixelBuffer);
+      pixelBuffer = nullptr;
+    }
   }
-  CVPixelBufferRelease(pixelBuffer);
-  pixelBuffer = nullptr;
 }
 } // namespace RNSkiaVideo


### PR DESCRIPTION
When composition items has many videos will crash by OOM.

in FrameDrawer({ frames }) have all decoder frames but it may be not required common use cases

Prevent initialize decoder at once, it handled by currentTime + 0.5sec (for transition two frames)
