### PR TITLE
fix: review bad seekTo arguments management

### DIFF
--- a/android/cpp/VideoCompositionFramesExtractorHostObject.cpp
+++ b/android/cpp/VideoCompositionFramesExtractorHostObject.cpp
@@ -79,7 +79,7 @@ jsi::Value VideoCompositionFramesExtractorHostObject::get(
         });
   } else if (propName == "seekTo") {
     return jsi::Function::createFromHostFunction(
-        runtime, jsi::PropNameID::forAscii(runtime, "seekTo"), 0,
+        runtime, jsi::PropNameID::forAscii(runtime, "seekTo"), 1,
         [this](jsi::Runtime& runtime, const jsi::Value& thisValue,
                const jsi::Value* arguments, size_t count) -> jsi::Value {
           if (!released.test()) {

--- a/ios/VideoCompositionFramesExtractorHostObject.mm
+++ b/ios/VideoCompositionFramesExtractorHostObject.mm
@@ -120,7 +120,7 @@ jsi::Value VideoCompositionFramesExtractorHostObject::get(
                const jsi::Value* arguments, size_t count) -> jsi::Value {
           if (!released) {
             seekTo(
-                CMTimeMakeWithSeconds(arguments[1].asNumber(), NSEC_PER_SEC));
+                CMTimeMakeWithSeconds(arguments[0].asNumber(), NSEC_PER_SEC));
           }
           return jsi::Value::undefined();
         });


### PR DESCRIPTION
Fix seekTo argument handling:
- on android: declared with 0 argument
- on ios: arguments[1] used instead of arguments[0]