### PR TITLE
fix: Skipped composition item frames

### DIFF
--- a/android/src/main/java/com/azzapp/rnskv/VideoCompositionItemDecoder.java
+++ b/android/src/main/java/com/azzapp/rnskv/VideoCompositionItemDecoder.java
@@ -266,7 +266,7 @@ public class VideoCompositionItemDecoder extends MediaCodec.Callback {
 
     List<Frame> framesToRenders = new ArrayList<>();
     for (Frame frame : pendingFrames) {
-      if (frame.presentationTimeUs - startTimeUs < compositionTimeUs - compositionStartTimeUs || !hasRenderedFrame) {
+      if (frame.presentationTimeUs - startTimeUs <= compositionTimeUs - compositionStartTimeUs || !hasRenderedFrame) {
         framesToRenders.add(frame);
         hasRenderedFrame = true;
       }


### PR DESCRIPTION
Hi folks 👋 first of all thanks for the amazing library using this extensively in a client project!

However, we noticed on Android devices that our output footage was choppy. After a lot of investigation we saw that the acquired `Image` from the `ImageReader`'s was missing some frames e.g. every 3rd one. Initially we thought this was an issue with the `ImageReader` reading a frame and then prematurely discarding it, but after even switching to `acquireNextImage` we got the same result pointing the image back to the `Surface` it was acquiring these images from. We then saw that in quick succession (only 1ms between) 2 buffer were release into the output surface from the `MediaCodec` on the `VideoCompositionItemDecoder.render` method. It then became apparent that this was skipping over frames that should have been rendered and then on the next iteration rendering both of them in quick succession here!

The fix was then just to simply improve the check you do for frame times in this method to be a `<=` which solved it. Now the frames that happened to have the exact same presentation time as the current render step in the composition e.g. 133333uS were correctly rendered into the Surface at that time step and then the `ImageReader` got an accurate image to work with. 

I believe you'd only ever see this issue in the case of the input and output having the same frame and no start time offset (as we do with our clips).