### PR TITLE
fix: invalid aspect ratio in decoder configuration

### DIFF
--- a/example/src/VideoCompositionExample.tsx
+++ b/example/src/VideoCompositionExample.tsx
@@ -327,7 +327,7 @@ const VideoCompositionPreview = ({
         bitRate: 12000000,
         frameRate: 60,
         width: 1920,
-        height: 1920,
+        height: 1080,
       };
 
       const validConfigs =


### PR DESCRIPTION
fix aspect ratio configuration in sample to export video with a correct supported decoder configuration