### PR TITLE
Fix Android build for React Native 0.76.9

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -131,6 +131,7 @@ android {
       "**/libhermes.so",
       "**/libhermes-executor-debug.so",
       "**/libhermes_executor.so",
+      "**/libreactnative.so",
       "**/libreactnativejni.so",
       "**/libturbomodulejsijni.so",
       "**/libreact_nativemodule_core.so",


### PR DESCRIPTION
Without this exclude, the build fails for React Native 0.76.9 (on Android).

Resolves https://github.com/AzzappApp/react-native-skia-video/issues/20