### PR TITLE
Fix black frame flicker on Mali GPUs

### DIFF
--- a/android/src/main/java/com/azzapp/rnskv/VideoEncoder.java
+++ b/android/src/main/java/com/azzapp/rnskv/VideoEncoder.java
@@ -118,6 +118,7 @@ public class VideoEncoder {
   }
 
   public void makeGLContextCurrent() {
+    GLES20.glFinish();
     eglResourcesHolder.makeCurrent();
   }
 


### PR DESCRIPTION
We see on some devices flickering frames in the exported video.

Skia video export produces intermittent black frames on Mali GPU devices (Pixel 7 Pro, Redmi Note 14) but works fine on Adreno (Samsung)
Root cause: makeGLContextCurrent() switches to the encoder's shared EGL context without ensuring Skia's GL commands have completed, violates the OpenGL ES shared-context texture synchronization requirement

This solves it by adding glFinish() before encoder context switch.