### PR TITLE
fix: fix iOS playbackSpeed getter always returning 0

### DIFF
--- a/ios/RNSVVideoPlayer.mm
+++ b/ios/RNSVVideoPlayer.mm
@@ -22,6 +22,7 @@ static void* rateContext = &rateContext;
   id<RNSVVideoPlayerDelegate> _delegate;
   Boolean _complete;
   Boolean _waitingForFrame;
+  float _playbackSpeed;
 }
 
 - (instancetype)initWithURL:(NSURL*)url
@@ -31,6 +32,7 @@ static void* rateContext = &rateContext;
   _delegate = delegate;
   _complete = NO;
   _waitingForFrame = YES;
+  _playbackSpeed = 1.0f;
 
   AVAsset* asset = [AVAsset assetWithURL:url];
   self.resolution = resolution;
@@ -102,8 +104,15 @@ static void* rateContext = &rateContext;
       (float)((volume < 0.0) ? 0.0 : ((volume > 1.0) ? 1.0 : volume));
 }
 
+- (float)playbackSpeed {
+  return _playbackSpeed;
+}
+
 - (void)setPlaybackSpeed:(float)playbackSpeed {
-  _player.rate = MAX(0.1f, playbackSpeed);
+  _playbackSpeed = MAX(0.1f, playbackSpeed);
+  if (_isPlaying) {
+    _player.rate = _playbackSpeed;
+  }
 }
 
 - (nullable id<MTLTexture>)getNextTextureForTime:(CMTime)time {
@@ -346,7 +355,7 @@ static void* rateContext = &rateContext;
     return;
   }
   if (_isPlaying && _player.rate == 0) {
-    [_player play];
+    _player.rate = _playbackSpeed;
   } else if (!_isPlaying && _player.rate != 0) {
     [_player pause];
   }
@@ -384,3 +393,4 @@ static void* rateContext = &rateContext;
 }
 
 @end
+


### PR DESCRIPTION
## Problem

`playbackSpeed` was always returning `0` on iOS, making speed controls non-functional.

## Root Cause

Three chained issues in `RNSVVideoPlayer.mm`:

1. **Missing instance variable** — No `_playbackSpeed` instance variable was declared, so the auto-generated getter always returned `0`

2. **Setter writing to wrong property** — `setPlaybackSpeed:` was writing directly to `_player.rate` instead of storing the value in `_playbackSpeed`. When the player was paused, AVPlayer reset the rate back to `0`.

3. **`updatePlayingState` ignoring playback speed** — `[_player play]` always resets the rate to `1.0`, completely ignoring the value set via `setPlaybackSpeed:`.

## Fix

- Added `float _playbackSpeed` ivar initialized to `1.0f`
- Added manual getter returning `_playbackSpeed`
- Fixed setter to store value in `_playbackSpeed` and only apply to `_player.rate` when playing
- Replaced `[_player play]` in `updatePlayingState` with `[_player setRate:_playbackSpeed]`

## Testing

Verified that `playbackSpeed` correctly returns the set value and that changing speed works while playing and is preserved across pause/resume.