### PR TITLE
fix(ios): honor slow-motion time mapping in composition decoder

### DIFF
--- a/ios/VideoCompositionItemDecoder.h
+++ b/ios/VideoCompositionItemDecoder.h
@@ -29,6 +29,7 @@ private:
   int rotation;
   AVURLAsset* asset;
   AVAssetTrack* videoTrack;
+  NSArray<AVAssetTrackSegment*>* segments;
   AVAssetReader* assetReader;
   id<MTLTexture> mtlTexture;
   std::list<std::pair<double, CMSampleBufferRef>> decodedFrames;
@@ -37,6 +38,7 @@ private:
   std::shared_ptr<VideoFrame> currentFrame;
 
   void setupReader(CMTime initialTime);
+  double mapSourceTimeToTarget(CMTime sourceTime);
 };
 
 } // namespace RNSkiaVideo

--- a/ios/VideoCompositionItemDecoder.mm
+++ b/ios/VideoCompositionItemDecoder.mm
@@ -26,6 +26,7 @@ VideoCompositionItemDecoder::VideoCompositionItemDecoder(
                      stringWithFormat:@"No video track for path: %@", path]
                }];
   }
+  segments = videoTrack.segments;
   width = videoTrack.naturalSize.width;
   height = videoTrack.naturalSize.height;
   rotation = AVAssetTrackUtils::GetTrackRotationInDegree(videoTrack);
@@ -83,6 +84,47 @@ void VideoCompositionItemDecoder::setupReader(CMTime initialTime) {
   [assetReader startReading];
 }
 
+// Slow-motion videos (e.g. those recorded by the iPhone camera) store every
+// frame in the short *source* (media) timeline but expose a stretched
+// presentation duration through the track's segment time mappings. The raw
+// AVAssetReaderTrackOutput hands us samples with their source timestamps and
+// ignores those mappings, so we remap each sample into the *target*
+// (presentation) timeline that the composition uses. For regular videos the
+// single segment is an identity mapping and this is a no-op.
+double VideoCompositionItemDecoder::mapSourceTimeToTarget(CMTime sourceTime) {
+  if (segments == nil || segments.count == 0) {
+    return CMTimeGetSeconds(sourceTime);
+  }
+  AVAssetTrackSegment* matching = nil;
+  for (AVAssetTrackSegment* segment in segments) {
+    if (segment.empty) {
+      continue;
+    }
+    CMTimeRange source = segment.timeMapping.source;
+    if (!CMTIMERANGE_IS_VALID(source) || source.duration.value == 0) {
+      continue;
+    }
+    if (CMTimeCompare(sourceTime, source.start) >= 0) {
+      // Keep the latest segment starting at or before the sample so that
+      // samples falling past a segment's end extrapolate from the nearest
+      // mapping instead of desyncing back to an identity timeline.
+      matching = segment;
+      if (CMTimeCompare(sourceTime, CMTimeRangeGetEnd(source)) < 0) {
+        break;
+      }
+    } else if (matching == nil) {
+      matching = segment;
+      break;
+    }
+  }
+  if (matching == nil) {
+    return CMTimeGetSeconds(sourceTime);
+  }
+  CMTime target = CMTimeMapTimeFromRangeToRange(
+      sourceTime, matching.timeMapping.source, matching.timeMapping.target);
+  return CMTimeGetSeconds(target);
+}
+
 #define DECODER_INPUT_TIME_ADVANCE 0.1
 
 void VideoCompositionItemDecoder::advanceDecoder(CMTime currentTime) {
@@ -133,15 +175,15 @@ void VideoCompositionItemDecoder::advanceDecoder(CMTime currentTime) {
         continue;
       }
       auto timeStamp = CMSampleBufferGetPresentationTimeStamp(sampleBuffer);
+      double targetSeconds = this->mapSourceTimeToTarget(timeStamp);
       auto buffer = CMSampleBufferGetImageBuffer(sampleBuffer);
       if (buffer) {
-        framesQueue->push_back(
-            std::make_pair(CMTimeGetSeconds(timeStamp), sampleBuffer));
+        framesQueue->push_back(std::make_pair(targetSeconds, sampleBuffer));
       } else {
         CFRelease(sampleBuffer);
       }
 
-      latestSampleTime = timeStamp;
+      latestSampleTime = CMTimeMakeWithSeconds(targetSeconds, NSEC_PER_SEC);
     }
   }
 }


### PR DESCRIPTION
## Problem

Slow-motion videos (e.g. those recorded by the iPhone camera) are decoded at **normal speed** in the composition path. For a clip with ~5s of real-time footage stretched to ~25s of slow-motion:

- **Non-looping extractor** (`createVideoCompositionFramesExtractorSync`, export/posts): plays the footage at normal speed for the first ~5s, then shows a **black frame** for the remaining duration.
- **Realtime extractor** (`createVideoCompositionFramesExtractor`, cover): **loops** the real-time portion at normal speed for the whole duration.

The simple `AVPlayer`-based player (`createVideoPlayer`) is unaffected — only the composition/export path is.

## Root cause

`VideoCompositionItemDecoder` reads the raw video track through `AVAssetReaderTrackOutput`. That output yields sample buffers with their **source (media) timestamps** and ignores the track's segment time mappings. iPhone slow-motion clips store every frame in a short *source* timeline but expose a stretched *presentation* duration via `AVAssetTrack.segments[].timeMapping`.

Everything else in the decoder (`item.startTime` / `duration` / `compositionStartTime`, the requested `currentTime`, the loop bounds) works in the **presentation (target)** timeline, but the queued frames carried **source** timestamps — so frame matching ran against the wrong timeline.

## Fix

Map each decoded sample's source timestamp into the presentation (target) timeline via the track's `AVAssetTrackSegment` time mappings (`CMTimeMapTimeFromRangeToRange`) before queueing it. This keeps the queue consistent with the target timeline used by the rest of the decoder.

- For **regular videos** the track has a single identity segment, so the mapping is a no-op (zero behavioral change / regression risk).
- Falls back to the raw timestamp when no segments are exposed.
- As a side effect, also fixes an over-read: `latestSampleTime` (previously a source timestamp) never reached `inputPosition` (a target time) for slow-mo, so the loop drained the whole reader on every tick.

## Testing

No native test harness exists in this repo (Jest covers TS only). Validate manually with a real iPhone slow-motion `.mov` in both extractors:

- **Non-looping / export**: no black tail — slow-motion plays over the full duration.
- **Realtime / cover**: no normal-speed loop — continuous slow-motion.

## Known limitation

`setupReader` still computes its `assetReader.timeRange` in the presentation timeline (unchanged). This is correct for non-trimmed clips and clips trimmed in the presentation timeline. If a future case surfaces a trimmed slow-motion clip starting at the wrong frame, the read range would also need a target→source mapping — that is the only remaining spot to revisit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
