### PR TITLE
feat: add audio support to video compositions

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,46 @@ exportVideoComposition({
 })
 ```
 
-> Please note that the Video Composition system currently does not support sound.
+#### Audio
+
+Video items are silent by default. To play the audio track of a video item
+(both during playback and export), set its `audio` option:
+
+```js
+const videoComposition = {
+  duration: 10,
+  items: [
+    {
+      id: 'video1',
+      path: 'path/to/video.mp4',
+      compositionStartTime: 0,
+      startTime: 0,
+      duration: 10,
+      // plays the audio track of video.mp4, in sync with its frames
+      audio: { volume: 0.8 }, // or simply `audio: true`
+    },
+    // additional audio (music, voice over...) can be added with an audio
+    // item; the source can be an audio file or the audio track of any
+    // video file
+    {
+      id: 'music',
+      kind: 'audio',
+      path: 'path/to/music.mp3',
+      compositionStartTime: 0,
+      startTime: 12,
+      duration: 10,
+      volume: 0.3,
+    },
+  ],
+};
+```
+
+Audio items never appear in the `frames` map passed to `drawFrame`.
+Overlapping audio is mixed together. During playback the audio is played in
+sync with the composition; during export it is encoded (AAC) into the output
+file. The exported audio can be configured through the `audioBitRate`
+(default 128kbps), `audioSampleRate` (default 44100Hz) and
+`audioChannelCount` (default 2) export options.
 
 
 ### Video Capabilities (Android only)

--- a/android/cpp/VideoComposition.cpp
+++ b/android/cpp/VideoComposition.cpp
@@ -72,22 +72,20 @@ VideoComposition::fromJSIObject(jsi::Runtime& runtime,
         jsItem.getProperty(runtime, "compositionStartTime").asNumber();
     auto startTime = jsItem.getProperty(runtime, "startTime").asNumber();
     auto duration = jsItem.getProperty(runtime, "duration").asNumber();
+
     auto item = VideoCompositionItem::create(id, path, compositionStartTime,
                                              startTime, duration);
-
+    auto itemCls = VideoCompositionItem::javaClassStatic();
     if (jsItem.hasProperty(runtime, "resolution")) {
       auto resProp = jsItem.getProperty(runtime, "resolution");
       if (resProp.isObject()) {
         auto res = resProp.asObject(runtime);
-        auto itemCls = VideoCompositionItem::javaClassStatic();
         item->setFieldValue(itemCls->getField<jint>("width"),
                             (int)res.getProperty(runtime, "width").asNumber());
         item->setFieldValue(itemCls->getField<jint>("height"),
                             (int)res.getProperty(runtime, "height").asNumber());
       }
     }
-
-    auto itemCls = VideoCompositionItem::javaClassStatic();
     bool isVideo = true;
     if (jsItem.hasProperty(runtime, "kind")) {
       auto kindProp = jsItem.getProperty(runtime, "kind");

--- a/android/cpp/VideoComposition.cpp
+++ b/android/cpp/VideoComposition.cpp
@@ -86,6 +86,46 @@ VideoComposition::fromJSIObject(jsi::Runtime& runtime,
                             (int)res.getProperty(runtime, "height").asNumber());
       }
     }
+
+    auto itemCls = VideoCompositionItem::javaClassStatic();
+    bool isVideo = true;
+    if (jsItem.hasProperty(runtime, "kind")) {
+      auto kindProp = jsItem.getProperty(runtime, "kind");
+      if (kindProp.isString()) {
+        isVideo = kindProp.asString(runtime).utf8(runtime) != "audio";
+      }
+    }
+    bool audioEnabled = false;
+    double audioVolume = 1.0;
+    if (!isVideo) {
+      audioEnabled = true;
+      if (jsItem.hasProperty(runtime, "volume")) {
+        auto volumeProp = jsItem.getProperty(runtime, "volume");
+        if (volumeProp.isNumber()) {
+          audioVolume = volumeProp.asNumber();
+        }
+      }
+    } else if (jsItem.hasProperty(runtime, "audio")) {
+      auto audioProp = jsItem.getProperty(runtime, "audio");
+      if (audioProp.isBool()) {
+        audioEnabled = audioProp.getBool();
+      } else if (audioProp.isObject()) {
+        audioEnabled = true;
+        auto audio = audioProp.asObject(runtime);
+        if (audio.hasProperty(runtime, "volume")) {
+          auto volumeProp = audio.getProperty(runtime, "volume");
+          if (volumeProp.isNumber()) {
+            audioVolume = volumeProp.asNumber();
+          }
+        }
+      }
+    }
+    item->setFieldValue(itemCls->getField<jboolean>("isVideo"),
+                        (jboolean)isVideo);
+    item->setFieldValue(itemCls->getField<jboolean>("audioEnabled"),
+                        (jboolean)audioEnabled);
+    item->setFieldValue(itemCls->getField<jdouble>("audioVolume"), audioVolume);
+
     items->add(item);
   }
   return VideoComposition::create(duration, items);

--- a/android/cpp/VideoEncoderHostObject.cpp
+++ b/android/cpp/VideoEncoderHostObject.cpp
@@ -10,9 +10,14 @@ using namespace facebook::jni;
 
 local_ref<VideoEncoder>
 VideoEncoder::create(std::string& outPath, int width, int height, int frameRate,
-                     int bitRate, std::optional<std::string> encoderName) {
+                     int bitRate, std::optional<std::string> encoderName,
+                     alias_ref<VideoComposition> composition,
+                     int audioSampleRate, int audioChannelCount,
+                     int audioBitRate) {
   return newInstance(outPath, width, height, frameRate, bitRate,
-                     encoderName.has_value() ? encoderName.value() : nullptr);
+                     encoderName.has_value() ? encoderName.value() : nullptr,
+                     composition, audioSampleRate, audioChannelCount,
+                     audioBitRate);
 }
 
 void VideoEncoder::prepare() const {
@@ -45,9 +50,12 @@ void VideoEncoder::finishWriting() const {
 
 VideoEncoderHostObject::VideoEncoderHostObject(
     std::string& outPath, int width, int height, int frameRate, int bitRate,
-    std::optional<std::string> encoderName) {
+    std::optional<std::string> encoderName,
+    alias_ref<VideoComposition> composition, int audioSampleRate,
+    int audioChannelCount, int audioBitRate) {
   framesExtractor = make_global(VideoEncoder::create(
-      outPath, width, height, frameRate, bitRate, encoderName));
+      outPath, width, height, frameRate, bitRate, encoderName, composition,
+      audioSampleRate, audioChannelCount, audioBitRate));
 }
 
 VideoEncoderHostObject::~VideoEncoderHostObject() {

--- a/android/cpp/VideoEncoderHostObject.h
+++ b/android/cpp/VideoEncoderHostObject.h
@@ -17,7 +17,11 @@ public:
 
   local_ref<VideoEncoder> static create(std::string& outPath, int width,
                                         int height, int frameRate, int bitRate,
-                                        std::optional<std::string> encoderName);
+                                        std::optional<std::string> encoderName,
+                                        alias_ref<VideoComposition> composition,
+                                        int audioSampleRate,
+                                        int audioChannelCount,
+                                        int audioBitRate);
 
   void prepare() const;
 
@@ -34,7 +38,10 @@ class JSI_EXPORT VideoEncoderHostObject : public jsi::HostObject {
 public:
   VideoEncoderHostObject(std::string& outPath, int width, int height,
                          int frameRate, int bitRate,
-                         std::optional<std::string> encoderName);
+                         std::optional<std::string> encoderName,
+                         alias_ref<VideoComposition> composition,
+                         int audioSampleRate, int audioChannelCount,
+                         int audioBitRate);
   ~VideoEncoderHostObject() override;
   jsi::Value get(jsi::Runtime&, const jsi::PropNameID& name) override;
   std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& rt) override;

--- a/android/cpp/cpp-adapter.cpp
+++ b/android/cpp/cpp-adapter.cpp
@@ -90,10 +90,10 @@ void install(jsi::Runtime& jsiRuntime) {
 
   auto createVideoEncoder = jsi::Function::createFromHostFunction(
       jsiRuntime, jsi::PropNameID::forAscii(jsiRuntime, "createVideoEncoder"),
-      1,
+      2,
       [](jsi::Runtime& runtime, const jsi::Value& thisValue,
          const jsi::Value* arguments, size_t count) -> jsi::Value {
-        if (count != 1 || !arguments[0].isObject()) {
+        if (count < 1 || !arguments[0].isObject()) {
           throw jsi::JSError(runtime, "ReactNativeSkiaVideo."
                                       "createVideoEncoder(.."
                                       ") expects one arguments (object)!");
@@ -115,9 +115,37 @@ void install(jsi::Runtime& jsiRuntime) {
             encoderName = value.asString(runtime).utf8(runtime);
           }
         }
+        int audioSampleRate = 44100;
+        int audioChannelCount = 2;
+        int audioBitRate = 128000;
+        if (options.hasProperty(runtime, "audioSampleRate")) {
+          auto value = options.getProperty(runtime, "audioSampleRate");
+          if (value.isNumber()) {
+            audioSampleRate = (int)value.asNumber();
+          }
+        }
+        if (options.hasProperty(runtime, "audioChannelCount")) {
+          auto value = options.getProperty(runtime, "audioChannelCount");
+          if (value.isNumber()) {
+            audioChannelCount = (int)value.asNumber();
+          }
+        }
+        if (options.hasProperty(runtime, "audioBitRate")) {
+          auto value = options.getProperty(runtime, "audioBitRate");
+          if (value.isNumber()) {
+            audioBitRate = (int)value.asNumber();
+          }
+        }
+
+        local_ref<VideoComposition> composition = nullptr;
+        if (count >= 2 && arguments[1].isObject()) {
+          auto jsComposition = arguments[1].asObject(runtime);
+          composition = VideoComposition::fromJSIObject(runtime, jsComposition);
+        }
 
         auto instance = std::make_shared<VideoEncoderHostObject>(
-            outPath, width, height, frameRate, bitRate, encoderName);
+            outPath, width, height, frameRate, bitRate, encoderName,
+            composition, audioSampleRate, audioChannelCount, audioBitRate);
         return jsi::Object::createFromHostObject(runtime, instance);
       });
   RNSVModule.setProperty(jsiRuntime, "createVideoEncoder",

--- a/android/src/main/java/com/azzapp/rnskv/AudioCompositionExporter.java
+++ b/android/src/main/java/com/azzapp/rnskv/AudioCompositionExporter.java
@@ -7,6 +7,7 @@ import android.media.MediaFormat;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.ShortBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -75,13 +76,13 @@ public class AudioCompositionExporter {
    * of the composition has been encoded and handed to the sink.
    */
   public void run() throws Exception {
-    List<ItemDecoder> itemDecoders = new ArrayList<>();
+    List<ItemSlot> slots = new ArrayList<>();
     try {
       for (VideoComposition.Item item : composition.getItems()) {
         if (!item.isAudioEnabled()) {
           continue;
         }
-        itemDecoders.add(new ItemDecoder(item));
+        slots.add(new ItemSlot(item));
       }
 
       encoder = MediaCodec.createEncoderByType(AUDIO_MIME_TYPE);
@@ -96,24 +97,41 @@ public class AudioCompositionExporter {
       encoder.start();
 
       long totalFrames = Math.round(composition.getDuration() * sampleRate);
-      short[] mixBuffer = new short[CHUNK_FRAMES * channelCount];
+      int[] mixBuffer = new int[CHUNK_FRAMES * channelCount];
       long framePosition = 0;
       while (framePosition < totalFrames) {
         if (isCanceled.getAsBoolean()) {
           return;
         }
         int chunkFrames = (int) Math.min(CHUNK_FRAMES, totalFrames - framePosition);
-        Arrays.fill(mixBuffer, (short) 0);
-        for (ItemDecoder itemDecoder : itemDecoders) {
-          itemDecoder.mixInto(mixBuffer, framePosition, chunkFrames);
+        long chunkEndFrame = framePosition + chunkFrames;
+        Arrays.fill(mixBuffer, 0);
+        for (ItemSlot slot : slots) {
+          if (slot.done || chunkEndFrame <= slot.startFrame) {
+            continue;
+          }
+          // Decoders are created when the timeline enters the item and
+          // released when it leaves it, so the number of simultaneous
+          // codec instances stays bounded by the overlapping items.
+          if (slot.decoder == null) {
+            slot.decoder = new ItemDecoder(slot.item);
+          }
+          slot.decoder.mixInto(mixBuffer, framePosition, chunkFrames);
+          if (chunkEndFrame >= slot.endFrame) {
+            slot.decoder.release();
+            slot.decoder = null;
+            slot.done = true;
+          }
         }
         queuePcm(mixBuffer, chunkFrames, framePosition);
         framePosition += chunkFrames;
       }
       queueEndOfStream();
     } finally {
-      for (ItemDecoder itemDecoder : itemDecoders) {
-        itemDecoder.release();
+      for (ItemSlot slot : slots) {
+        if (slot.decoder != null) {
+          slot.decoder.release();
+        }
       }
       if (encoder != null) {
         try {
@@ -126,7 +144,7 @@ public class AudioCompositionExporter {
     }
   }
 
-  private void queuePcm(short[] samples, int frames, long framePosition) {
+  private void queuePcm(int[] samples, int frames, long framePosition) {
     int bytesPerFrame = channelCount * 2;
     int totalBytes = frames * bytesPerFrame;
     int offsetBytes = 0;
@@ -149,7 +167,14 @@ public class AudioCompositionExporter {
       input.order(ByteOrder.LITTLE_ENDIAN);
       int bytes = Math.min(input.remaining(), totalBytes - offsetBytes);
       bytes -= bytes % bytesPerFrame;
-      input.asShortBuffer().put(samples, offsetBytes / 2, bytes / 2);
+      ShortBuffer shortBuffer = input.asShortBuffer();
+      int sampleOffset = offsetBytes / 2;
+      int sampleCount = bytes / 2;
+      for (int i = 0; i < sampleCount; i++) {
+        int sample = samples[sampleOffset + i];
+        shortBuffer.put(
+          (short) Math.max(Short.MIN_VALUE, Math.min(Short.MAX_VALUE, sample)));
+      }
       long ptsUs =
         (framePosition + offsetBytes / bytesPerFrame) * 1000000L / sampleRate;
       encoder.queueInputBuffer(inputIndex, 0, bytes, ptsUs, 0);
@@ -208,6 +233,24 @@ public class AudioCompositionExporter {
           break;
         }
       }
+    }
+  }
+
+  /**
+   * An audio-enabled item of the composition and its decoder; the decoder
+   * only exists while the export timeline overlaps the item.
+   */
+  private class ItemSlot {
+    final VideoComposition.Item item;
+    final long startFrame;
+    final long endFrame;
+    ItemDecoder decoder;
+    boolean done = false;
+
+    ItemSlot(VideoComposition.Item item) {
+      this.item = item;
+      startFrame = Math.round(item.getCompositionStartTime() * sampleRate);
+      endFrame = startFrame + Math.round(item.getDuration() * sampleRate);
     }
   }
 
@@ -298,7 +341,7 @@ public class AudioCompositionExporter {
       }
     }
 
-    void mixInto(short[] mix, long chunkStartFrame, int frames) {
+    void mixInto(int[] mix, long chunkStartFrame, int frames) {
       if (!hasAudioTrack) {
         return;
       }
@@ -319,9 +362,10 @@ public class AudioCompositionExporter {
         for (int channel = 0; channel < channelCount; channel++) {
           double sample = readSample(srcFrameIndex, channel) * (1 - fraction)
             + readSample(srcFrameIndex + 1, channel) * fraction;
-          int mixed = mix[mixIndex + channel] + (int) Math.round(sample * volume);
-          mix[mixIndex + channel] =
-            (short) Math.max(Short.MIN_VALUE, Math.min(Short.MAX_VALUE, mixed));
+          // Clipping only happens once every track has been accumulated
+          // (in queuePcm), otherwise the result would depend on the order
+          // of the items.
+          mix[mixIndex + channel] += (int) Math.round(sample * volume);
         }
       }
       // Drop the consumed samples to keep memory bounded.
@@ -408,17 +452,20 @@ public class AudioCompositionExporter {
         int frames = sampleCount / srcChannelCount;
         int skipFrames = 0;
         if (firstBuffer) {
-          // Drop the samples decoded before the item start time (the
-          // extractor sought to a preceding sync point).
           firstBuffer = false;
-          skipFrames = (int) Math.max(
-            0,
-            Math.round(
-              (startTimeUs - decoderBufferInfo.presentationTimeUs)
-                * srcSampleRate / 1000000.0
-            )
-          );
-          skipFrames = Math.min(skipFrames, frames);
+          long offsetUs = decoderBufferInfo.presentationTimeUs - startTimeUs;
+          if (offsetUs < 0) {
+            // Drop the samples decoded before the item start time (the
+            // extractor sought to a preceding sync point).
+            skipFrames = (int) Math.min(
+              Math.round(-offsetUs * srcSampleRate / 1000000.0),
+              frames
+            );
+          } else if (offsetUs > 0) {
+            // The audio starts after the requested start time: keep the
+            // offset so the audio stays aligned on the composition timeline.
+            bufferStartFrame = Math.round(offsetUs * srcSampleRate / 1000000.0);
+          }
         }
         int keptFrames = frames - skipFrames;
         if (keptFrames > 0) {

--- a/android/src/main/java/com/azzapp/rnskv/AudioCompositionExporter.java
+++ b/android/src/main/java/com/azzapp/rnskv/AudioCompositionExporter.java
@@ -1,0 +1,476 @@
+package com.azzapp.rnskv;
+
+import android.media.MediaCodec;
+import android.media.MediaCodecInfo;
+import android.media.MediaExtractor;
+import android.media.MediaFormat;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.BooleanSupplier;
+
+/**
+ * Decodes, mixes and encodes (AAC) the audio of the audio-enabled items of a
+ * video composition. The pipeline is synchronous and meant to be run on a
+ * dedicated thread, in parallel of the video frames encoding.
+ */
+public class AudioCompositionExporter {
+
+  public static final String AUDIO_MIME_TYPE = "audio/mp4a-latm";
+
+  private static final int CHUNK_FRAMES = 2048;
+
+  private static final long CODEC_TIMEOUT_US = 10000;
+
+  private static final int MAX_STALLED_ITERATIONS = 1000;
+
+  /**
+   * Receives the encoded AAC samples, on the thread running {@link #run}.
+   */
+  public interface Sink {
+    void onAudioFormat(MediaFormat format);
+
+    void onAudioSample(ByteBuffer buffer, MediaCodec.BufferInfo bufferInfo);
+  }
+
+  private final VideoComposition composition;
+
+  private final int sampleRate;
+
+  private final int channelCount;
+
+  private final int bitRate;
+
+  private final Sink sink;
+
+  private final BooleanSupplier isCanceled;
+
+  private MediaCodec encoder;
+
+  private final MediaCodec.BufferInfo encoderBufferInfo = new MediaCodec.BufferInfo();
+
+  private boolean formatDispatched = false;
+
+  public AudioCompositionExporter(
+    VideoComposition composition,
+    int sampleRate,
+    int channelCount,
+    int bitRate,
+    Sink sink,
+    BooleanSupplier isCanceled
+  ) {
+    this.composition = composition;
+    this.sampleRate = sampleRate;
+    this.channelCount = channelCount;
+    this.bitRate = bitRate;
+    this.sink = sink;
+    this.isCanceled = isCanceled;
+  }
+
+  /**
+   * Runs the whole audio export pipeline, returns once every audio sample
+   * of the composition has been encoded and handed to the sink.
+   */
+  public void run() throws Exception {
+    List<ItemDecoder> itemDecoders = new ArrayList<>();
+    try {
+      for (VideoComposition.Item item : composition.getItems()) {
+        if (!item.isAudioEnabled()) {
+          continue;
+        }
+        itemDecoders.add(new ItemDecoder(item));
+      }
+
+      encoder = MediaCodec.createEncoderByType(AUDIO_MIME_TYPE);
+      MediaFormat format =
+        MediaFormat.createAudioFormat(AUDIO_MIME_TYPE, sampleRate, channelCount);
+      format.setInteger(
+        MediaFormat.KEY_AAC_PROFILE,
+        MediaCodecInfo.CodecProfileLevel.AACObjectLC
+      );
+      format.setInteger(MediaFormat.KEY_BIT_RATE, bitRate);
+      encoder.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE);
+      encoder.start();
+
+      long totalFrames = Math.round(composition.getDuration() * sampleRate);
+      short[] mixBuffer = new short[CHUNK_FRAMES * channelCount];
+      long framePosition = 0;
+      while (framePosition < totalFrames) {
+        if (isCanceled.getAsBoolean()) {
+          return;
+        }
+        int chunkFrames = (int) Math.min(CHUNK_FRAMES, totalFrames - framePosition);
+        Arrays.fill(mixBuffer, (short) 0);
+        for (ItemDecoder itemDecoder : itemDecoders) {
+          itemDecoder.mixInto(mixBuffer, framePosition, chunkFrames);
+        }
+        queuePcm(mixBuffer, chunkFrames, framePosition);
+        framePosition += chunkFrames;
+      }
+      queueEndOfStream();
+    } finally {
+      for (ItemDecoder itemDecoder : itemDecoders) {
+        itemDecoder.release();
+      }
+      if (encoder != null) {
+        try {
+          encoder.stop();
+        } catch (IllegalStateException ignored) {
+        }
+        encoder.release();
+        encoder = null;
+      }
+    }
+  }
+
+  private void queuePcm(short[] samples, int frames, long framePosition) {
+    int bytesPerFrame = channelCount * 2;
+    int totalBytes = frames * bytesPerFrame;
+    int offsetBytes = 0;
+    int stalled = 0;
+    while (offsetBytes < totalBytes) {
+      int inputIndex = encoder.dequeueInputBuffer(CODEC_TIMEOUT_US);
+      if (inputIndex < 0) {
+        drainEncoder(false);
+        if (++stalled > MAX_STALLED_ITERATIONS) {
+          throw new RuntimeException("Audio encoder stalled");
+        }
+        continue;
+      }
+      stalled = 0;
+      ByteBuffer input = encoder.getInputBuffer(inputIndex);
+      if (input == null) {
+        throw new RuntimeException("Audio encoder input buffer was null");
+      }
+      input.clear();
+      input.order(ByteOrder.LITTLE_ENDIAN);
+      int bytes = Math.min(input.remaining(), totalBytes - offsetBytes);
+      bytes -= bytes % bytesPerFrame;
+      input.asShortBuffer().put(samples, offsetBytes / 2, bytes / 2);
+      long ptsUs =
+        (framePosition + offsetBytes / bytesPerFrame) * 1000000L / sampleRate;
+      encoder.queueInputBuffer(inputIndex, 0, bytes, ptsUs, 0);
+      offsetBytes += bytes;
+      drainEncoder(false);
+    }
+  }
+
+  private void queueEndOfStream() {
+    int stalled = 0;
+    while (true) {
+      int inputIndex = encoder.dequeueInputBuffer(CODEC_TIMEOUT_US);
+      if (inputIndex >= 0) {
+        encoder.queueInputBuffer(
+          inputIndex, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM);
+        break;
+      }
+      drainEncoder(false);
+      if (++stalled > MAX_STALLED_ITERATIONS) {
+        throw new RuntimeException("Audio encoder stalled");
+      }
+    }
+    drainEncoder(true);
+  }
+
+  private void drainEncoder(boolean endOfStream) {
+    while (true) {
+      int encoderStatus =
+        encoder.dequeueOutputBuffer(encoderBufferInfo, endOfStream ? CODEC_TIMEOUT_US : 0);
+      if (encoderStatus == MediaCodec.INFO_TRY_AGAIN_LATER) {
+        if (!endOfStream) {
+          break;
+        }
+      } else if (encoderStatus == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
+        if (formatDispatched) {
+          throw new RuntimeException("Audio format changed twice");
+        }
+        formatDispatched = true;
+        sink.onAudioFormat(encoder.getOutputFormat());
+      } else if (encoderStatus >= 0) {
+        ByteBuffer encodedData = encoder.getOutputBuffer(encoderStatus);
+        if (encodedData == null) {
+          throw new RuntimeException(
+            "audioEncoderOutputBuffer " + encoderStatus + " was null");
+        }
+        if ((encoderBufferInfo.flags & MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0) {
+          encoderBufferInfo.size = 0;
+        }
+        if (encoderBufferInfo.size != 0) {
+          encodedData.position(encoderBufferInfo.offset);
+          encodedData.limit(encoderBufferInfo.offset + encoderBufferInfo.size);
+          sink.onAudioSample(encodedData, encoderBufferInfo);
+        }
+        encoder.releaseOutputBuffer(encoderStatus, false);
+        if ((encoderBufferInfo.flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+          break;
+        }
+      }
+    }
+  }
+
+  /**
+   * Decodes the audio track of a composition item, resampled to the output
+   * sample rate/channel count, and mixes it into the composition timeline.
+   */
+  private class ItemDecoder {
+
+    private final long itemStartFrame;
+
+    private final long itemEndFrame;
+
+    private final double volume;
+
+    private final long startTimeUs;
+
+    private final long endTimeUs;
+
+    private final MediaExtractor extractor;
+
+    private MediaCodec decoder;
+
+    private boolean hasAudioTrack = true;
+
+    private int srcSampleRate;
+
+    private int srcChannelCount;
+
+    private boolean inputDone = false;
+
+    private boolean outputDone = false;
+
+    private boolean firstBuffer = true;
+
+    private final MediaCodec.BufferInfo decoderBufferInfo = new MediaCodec.BufferInfo();
+
+    // Decoded source samples (interleaved), starting at bufferStartFrame
+    // (source frame index, 0 = item startTime).
+    private short[] buffer = new short[0];
+
+    private long bufferStartFrame = 0;
+
+    private int bufferFrames = 0;
+
+    ItemDecoder(VideoComposition.Item item) throws Exception {
+      itemStartFrame = Math.round(item.getCompositionStartTime() * sampleRate);
+      itemEndFrame = itemStartFrame + Math.round(item.getDuration() * sampleRate);
+      volume = Math.max(0, Math.min(1, item.getAudioVolume()));
+      startTimeUs = TimeHelpers.secToUs(item.getStartTime());
+      endTimeUs = startTimeUs + TimeHelpers.secToUs(item.getDuration());
+
+      extractor = new MediaExtractor();
+      try {
+        extractor.setDataSource(item.getPath());
+        int audioTrackIndex = -1;
+        MediaFormat audioFormat = null;
+        for (int i = 0; i < extractor.getTrackCount(); i++) {
+          MediaFormat trackFormat = extractor.getTrackFormat(i);
+          String mime = trackFormat.getString(MediaFormat.KEY_MIME);
+          if (mime != null && mime.startsWith("audio/")) {
+            audioTrackIndex = i;
+            audioFormat = trackFormat;
+            break;
+          }
+        }
+        if (audioTrackIndex == -1) {
+          if (item.isVideo()) {
+            // Video item without audio track: keep it silent.
+            hasAudioTrack = false;
+            return;
+          }
+          throw new RuntimeException(
+            "No audio track for path: " + item.getPath());
+        }
+        extractor.selectTrack(audioTrackIndex);
+        extractor.seekTo(startTimeUs, MediaExtractor.SEEK_TO_PREVIOUS_SYNC);
+
+        srcSampleRate = audioFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE);
+        srcChannelCount = audioFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT);
+        String mime = audioFormat.getString(MediaFormat.KEY_MIME);
+        decoder = MediaCodec.createDecoderByType(mime);
+        decoder.configure(audioFormat, null, null, 0);
+        decoder.start();
+      } catch (Exception e) {
+        release();
+        throw e;
+      }
+    }
+
+    void mixInto(short[] mix, long chunkStartFrame, int frames) {
+      if (!hasAudioTrack) {
+        return;
+      }
+      long overlapStart = Math.max(chunkStartFrame, itemStartFrame);
+      long overlapEnd = Math.min(chunkStartFrame + frames, itemEndFrame);
+      if (overlapEnd <= overlapStart) {
+        return;
+      }
+      for (long frame = overlapStart; frame < overlapEnd; frame++) {
+        long localFrame = frame - itemStartFrame;
+        double srcFrame = localFrame * srcSampleRate / (double) sampleRate;
+        long srcFrameIndex = (long) srcFrame;
+        if (!ensureSamplesUpTo(srcFrameIndex + 2)) {
+          break;
+        }
+        double fraction = srcFrame - srcFrameIndex;
+        int mixIndex = (int) (frame - chunkStartFrame) * channelCount;
+        for (int channel = 0; channel < channelCount; channel++) {
+          double sample = readSample(srcFrameIndex, channel) * (1 - fraction)
+            + readSample(srcFrameIndex + 1, channel) * fraction;
+          int mixed = mix[mixIndex + channel] + (int) Math.round(sample * volume);
+          mix[mixIndex + channel] =
+            (short) Math.max(Short.MIN_VALUE, Math.min(Short.MAX_VALUE, mixed));
+        }
+      }
+      // Drop the consumed samples to keep memory bounded.
+      long consumedUpTo =
+        (long) ((overlapEnd - 1 - itemStartFrame) * srcSampleRate / (double) sampleRate);
+      dropSamplesBefore(consumedUpTo - 2);
+    }
+
+    private double readSample(long srcFrameIndex, int outChannel) {
+      long index = srcFrameIndex - bufferStartFrame;
+      if (index < 0 || index >= bufferFrames) {
+        return 0;
+      }
+      int frameOffset = (int) index * srcChannelCount;
+      if (channelCount == 1 && srcChannelCount > 1) {
+        // Downmix to mono: average the source channels.
+        double sum = 0;
+        for (int channel = 0; channel < srcChannelCount; channel++) {
+          sum += buffer[frameOffset + channel];
+        }
+        return sum / srcChannelCount;
+      }
+      return buffer[frameOffset + Math.min(outChannel, srcChannelCount - 1)];
+    }
+
+    private boolean ensureSamplesUpTo(long srcFrameEnd) {
+      int stalled = 0;
+      while (bufferStartFrame + bufferFrames < srcFrameEnd) {
+        if (outputDone) {
+          // Past the end of the source: the remaining frames stay silent.
+          return bufferStartFrame + bufferFrames > 0
+            && srcFrameEnd - (bufferStartFrame + bufferFrames) < 2;
+        }
+        if (!pumpDecoder()) {
+          if (++stalled > MAX_STALLED_ITERATIONS) {
+            throw new RuntimeException("Audio decoder stalled");
+          }
+        } else {
+          stalled = 0;
+        }
+      }
+      return true;
+    }
+
+    private boolean pumpDecoder() {
+      boolean progressed = false;
+      if (!inputDone) {
+        int inputIndex = decoder.dequeueInputBuffer(0);
+        if (inputIndex >= 0) {
+          ByteBuffer input = decoder.getInputBuffer(inputIndex);
+          int size = input != null ? extractor.readSampleData(input, 0) : -1;
+          long sampleTimeUs = extractor.getSampleTime();
+          if (size < 0 || sampleTimeUs >= endTimeUs) {
+            decoder.queueInputBuffer(
+              inputIndex, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM);
+            inputDone = true;
+          } else {
+            decoder.queueInputBuffer(inputIndex, 0, size, sampleTimeUs, 0);
+            extractor.advance();
+          }
+          progressed = true;
+        }
+      }
+
+      int outputIndex = decoder.dequeueOutputBuffer(decoderBufferInfo, CODEC_TIMEOUT_US);
+      if (outputIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
+        MediaFormat outputFormat = decoder.getOutputFormat();
+        srcSampleRate = outputFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE);
+        srcChannelCount = outputFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT);
+        return true;
+      }
+      if (outputIndex < 0) {
+        return progressed;
+      }
+      if ((decoderBufferInfo.flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+        outputDone = true;
+      }
+      ByteBuffer output = decoder.getOutputBuffer(outputIndex);
+      if (output != null && decoderBufferInfo.size > 0) {
+        output.position(decoderBufferInfo.offset);
+        output.limit(decoderBufferInfo.offset + decoderBufferInfo.size);
+        output.order(ByteOrder.LITTLE_ENDIAN);
+        int sampleCount = decoderBufferInfo.size / 2;
+        int frames = sampleCount / srcChannelCount;
+        int skipFrames = 0;
+        if (firstBuffer) {
+          // Drop the samples decoded before the item start time (the
+          // extractor sought to a preceding sync point).
+          firstBuffer = false;
+          skipFrames = (int) Math.max(
+            0,
+            Math.round(
+              (startTimeUs - decoderBufferInfo.presentationTimeUs)
+                * srcSampleRate / 1000000.0
+            )
+          );
+          skipFrames = Math.min(skipFrames, frames);
+        }
+        int keptFrames = frames - skipFrames;
+        if (keptFrames > 0) {
+          appendSamples(output, skipFrames * srcChannelCount, keptFrames);
+        }
+      }
+      decoder.releaseOutputBuffer(outputIndex, false);
+      return true;
+    }
+
+    private void appendSamples(ByteBuffer output, int skipSamples, int frames) {
+      int requiredFrames = bufferFrames + frames;
+      int requiredLength = requiredFrames * srcChannelCount;
+      if (buffer.length < requiredLength) {
+        buffer = Arrays.copyOf(buffer, Math.max(requiredLength, buffer.length * 2));
+      }
+      output.position(output.position() + skipSamples * 2);
+      output.asShortBuffer().get(
+        buffer, bufferFrames * srcChannelCount, frames * srcChannelCount);
+      bufferFrames = requiredFrames;
+    }
+
+    private void dropSamplesBefore(long srcFrame) {
+      long dropFrames = srcFrame - bufferStartFrame;
+      if (dropFrames <= 0) {
+        return;
+      }
+      dropFrames = Math.min(dropFrames, bufferFrames);
+      int remainingFrames = bufferFrames - (int) dropFrames;
+      if (remainingFrames > 0) {
+        System.arraycopy(
+          buffer,
+          (int) dropFrames * srcChannelCount,
+          buffer,
+          0,
+          remainingFrames * srcChannelCount
+        );
+      }
+      bufferStartFrame += dropFrames;
+      bufferFrames = remainingFrames;
+    }
+
+    void release() {
+      if (decoder != null) {
+        try {
+          decoder.stop();
+        } catch (IllegalStateException ignored) {
+        }
+        decoder.release();
+        decoder = null;
+      }
+      extractor.release();
+    }
+  }
+}

--- a/android/src/main/java/com/azzapp/rnskv/AudioCompositionPlayer.java
+++ b/android/src/main/java/com/azzapp/rnskv/AudioCompositionPlayer.java
@@ -1,0 +1,237 @@
+package com.azzapp.rnskv;
+
+import android.net.Uri;
+import android.os.Looper;
+import android.os.SystemClock;
+
+import androidx.media3.common.C;
+import androidx.media3.common.MediaItem;
+import androidx.media3.common.PlaybackParameters;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.exoplayer.ExoPlayer;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Plays the audio of the audio-enabled items of a video composition during
+ * playback. One audio only ExoPlayer is created per audio-enabled item and
+ * slaved to the composition clock through the {@link #update} method.
+ * Every method must be called on the thread that called {@link #prepare}.
+ */
+@UnstableApi
+public class AudioCompositionPlayer {
+
+  // Drift above which a player is hard-seeked (audible); smaller drifts are
+  // caught up by adjusting the playback speed (pitch preserving, inaudible).
+  private static final long HARD_RESYNC_US = 500000;
+
+  // Speed adjustment hysteresis: starts above 60ms of drift, stops under 20ms.
+  private static final long DRIFT_ADJUST_START_US = 60000;
+  private static final long DRIFT_ADJUST_STOP_US = 20000;
+
+  private static final float CATCH_UP_SPEED = 1.05f;
+  private static final float SLOW_DOWN_SPEED = 0.95f;
+
+  // Minimum delay between two hard resyncs of the same item; without it a
+  // player whose seek latency exceeds the threshold re-seeks on every tick.
+  private static final long RESYNC_COOLDOWN_MS = 1000;
+
+  // Window after a start during which the observed drift is attributed to
+  // the audio pipeline startup latency and learned as the seek lead.
+  private static final long START_LEARN_WINDOW_MS = 2000;
+
+  private static final long MAX_SEEK_LEAD_US = 1000000;
+
+  private final VideoComposition composition;
+
+  private final List<ItemPlayer> itemPlayers = new ArrayList<>();
+
+  private boolean released = false;
+
+  public AudioCompositionPlayer(VideoComposition composition) {
+    this.composition = composition;
+  }
+
+  public void prepare() {
+    for (VideoComposition.Item item : composition.getItems()) {
+      if (!item.isAudioEnabled()) {
+        continue;
+      }
+      itemPlayers.add(new ItemPlayer(item));
+    }
+  }
+
+  /**
+   * Synchronizes the item players with the composition clock.
+   */
+  public void update(long positionUs, boolean isPlaying) {
+    if (released) {
+      return;
+    }
+    for (ItemPlayer itemPlayer : itemPlayers) {
+      itemPlayer.update(positionUs, isPlaying);
+    }
+  }
+
+  public void seekTo(long positionUs) {
+    if (released) {
+      return;
+    }
+    for (ItemPlayer itemPlayer : itemPlayers) {
+      itemPlayer.seekTo(positionUs);
+    }
+  }
+
+  public void pause() {
+    if (released) {
+      return;
+    }
+    for (ItemPlayer itemPlayer : itemPlayers) {
+      itemPlayer.pause();
+    }
+  }
+
+  public void release() {
+    if (released) {
+      return;
+    }
+    released = true;
+    for (ItemPlayer itemPlayer : itemPlayers) {
+      itemPlayer.release();
+    }
+    itemPlayers.clear();
+  }
+
+  private static class ItemPlayer {
+    private final ExoPlayer player;
+    private final long compositionStartTimeUs;
+    private final long durationUs;
+
+    // Learned seek/startup latency: seeking lands the player behind the
+    // composition clock by the time the audio pipeline takes to resume,
+    // leading every seek by the observed drift compensates it.
+    private long seekLeadUs = 0;
+
+    private long lastSyncElapsedMs = -1;
+
+    private long lastStartElapsedMs = -1;
+
+    private float currentSpeed = 1f;
+
+    ItemPlayer(VideoComposition.Item item) {
+      compositionStartTimeUs = TimeHelpers.secToUs(item.getCompositionStartTime());
+      durationUs = TimeHelpers.secToUs(item.getDuration());
+
+      player = new ExoPlayer.Builder(
+        ReactNativeSkiaVideoModule.currentReactApplicationContext()
+      ).setLooper(Looper.myLooper()).build();
+
+      String path = item.getPath();
+      Uri uri = path.startsWith("/") ? Uri.fromFile(new File(path)) : Uri.parse(path);
+      long startTimeMs = Math.round(item.getStartTime() * 1000);
+      long endTimeMs = startTimeMs + Math.round(item.getDuration() * 1000);
+      MediaItem mediaItem = new MediaItem.Builder()
+        .setUri(uri)
+        .setClippingConfiguration(
+          new MediaItem.ClippingConfiguration.Builder()
+            .setStartPositionMs(startTimeMs)
+            .setEndPositionMs(endTimeMs)
+            .build()
+        )
+        .build();
+      player.setMediaItem(mediaItem);
+      // Disabling video ensures a video file used as an audio source never
+      // instantiates a video decoder.
+      player.setTrackSelectionParameters(
+        player.getTrackSelectionParameters().buildUpon()
+          .setTrackTypeDisabled(C.TRACK_TYPE_VIDEO, true)
+          .build()
+      );
+      player.setVolume((float) Math.max(0, Math.min(1, item.getAudioVolume())));
+      player.setPlayWhenReady(false);
+      player.prepare();
+    }
+
+    void update(long positionUs, boolean isPlaying) {
+      long localPositionUs = positionUs - compositionStartTimeUs;
+      boolean active =
+        isPlaying && localPositionUs >= 0 && localPositionUs < durationUs;
+      if (!active) {
+        if (player.getPlayWhenReady()) {
+          player.setPlayWhenReady(false);
+        }
+        return;
+      }
+      if (!player.getPlayWhenReady()) {
+        // The player is usually already primed at the target position
+        // (prepare, user seek, loop restart): starting it without seeking
+        // avoids the seek + rebuffering latency at the start of playback.
+        long playerPositionUs = player.getCurrentPosition() * 1000;
+        long targetUs = localPositionUs + seekLeadUs;
+        if (Math.abs(playerPositionUs - targetUs) > DRIFT_ADJUST_START_US) {
+          syncTo(localPositionUs);
+        }
+        setSpeed(1f);
+        player.setPlayWhenReady(true);
+        lastStartElapsedMs = SystemClock.elapsedRealtime();
+        lastSyncElapsedMs = lastStartElapsedMs;
+        return;
+      }
+      if (!player.isPlaying()) {
+        // Still buffering after a seek/start.
+        return;
+      }
+      long playerPositionUs = player.getCurrentPosition() * 1000;
+      long driftUs = localPositionUs - playerPositionUs;
+      long absDriftUs = Math.abs(driftUs);
+      long nowMs = SystemClock.elapsedRealtime();
+
+      if (
+        driftUs > 0
+          && lastStartElapsedMs >= 0
+          && nowMs - lastStartElapsedMs < START_LEARN_WINDOW_MS
+      ) {
+        seekLeadUs = Math.min(Math.max(seekLeadUs, driftUs), MAX_SEEK_LEAD_US);
+      }
+
+      if (absDriftUs > HARD_RESYNC_US) {
+        if (lastSyncElapsedMs < 0 || nowMs - lastSyncElapsedMs >= RESYNC_COOLDOWN_MS) {
+          syncTo(localPositionUs);
+          setSpeed(1f);
+        }
+      } else if (absDriftUs > DRIFT_ADJUST_START_US) {
+        setSpeed(driftUs > 0 ? CATCH_UP_SPEED : SLOW_DOWN_SPEED);
+      } else if (absDriftUs < DRIFT_ADJUST_STOP_US) {
+        setSpeed(1f);
+      }
+    }
+
+    private void setSpeed(float speed) {
+      if (currentSpeed != speed) {
+        currentSpeed = speed;
+        player.setPlaybackParameters(new PlaybackParameters(speed));
+      }
+    }
+
+    void seekTo(long positionUs) {
+      long localPositionUs =
+        Math.max(0, Math.min(positionUs - compositionStartTimeUs, durationUs));
+      syncTo(localPositionUs);
+    }
+
+    private void syncTo(long localPositionUs) {
+      player.seekTo((localPositionUs + seekLeadUs) / 1000);
+      lastSyncElapsedMs = SystemClock.elapsedRealtime();
+    }
+
+    void pause() {
+      player.setPlayWhenReady(false);
+    }
+
+    void release() {
+      player.release();
+    }
+  }
+}

--- a/android/src/main/java/com/azzapp/rnskv/AudioCompositionPlayer.java
+++ b/android/src/main/java/com/azzapp/rnskv/AudioCompositionPlayer.java
@@ -6,7 +6,10 @@ import android.os.SystemClock;
 
 import androidx.media3.common.C;
 import androidx.media3.common.MediaItem;
+import androidx.media3.common.PlaybackException;
 import androidx.media3.common.PlaybackParameters;
+import androidx.media3.common.Player;
+import androidx.media3.common.Tracks;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.exoplayer.ExoPlayer;
 
@@ -22,6 +25,10 @@ import java.util.List;
  */
 @UnstableApi
 public class AudioCompositionPlayer {
+
+  public interface OnErrorListener {
+    void onError(String message);
+  }
 
   // Drift above which a player is hard-seeked (audible); smaller drifts are
   // caught up by adjusting the playback speed (pitch preserving, inaudible).
@@ -48,10 +55,16 @@ public class AudioCompositionPlayer {
 
   private final List<ItemPlayer> itemPlayers = new ArrayList<>();
 
+  private OnErrorListener onErrorListener;
+
   private boolean released = false;
 
   public AudioCompositionPlayer(VideoComposition composition) {
     this.composition = composition;
+  }
+
+  public void setOnErrorListener(OnErrorListener onErrorListener) {
+    this.onErrorListener = onErrorListener;
   }
 
   public void prepare() {
@@ -59,7 +72,13 @@ public class AudioCompositionPlayer {
       if (!item.isAudioEnabled()) {
         continue;
       }
-      itemPlayers.add(new ItemPlayer(item));
+      itemPlayers.add(new ItemPlayer(item, this::dispatchError));
+    }
+  }
+
+  private void dispatchError(String message) {
+    if (!released && onErrorListener != null) {
+      onErrorListener.onError(message);
     }
   }
 
@@ -120,13 +139,36 @@ public class AudioCompositionPlayer {
 
     private float currentSpeed = 1f;
 
-    ItemPlayer(VideoComposition.Item item) {
+    ItemPlayer(VideoComposition.Item item, OnErrorListener onErrorListener) {
       compositionStartTimeUs = TimeHelpers.secToUs(item.getCompositionStartTime());
       durationUs = TimeHelpers.secToUs(item.getDuration());
 
       player = new ExoPlayer.Builder(
         ReactNativeSkiaVideoModule.currentReactApplicationContext()
       ).setLooper(Looper.myLooper()).build();
+
+      player.addListener(new Player.Listener() {
+        private boolean audioTrackChecked = false;
+
+        @Override
+        public void onPlayerError(PlaybackException error) {
+          onErrorListener.onError(error.getMessage());
+        }
+
+        @Override
+        public void onTracksChanged(Tracks tracks) {
+          if (item.isVideo() || audioTrackChecked || tracks.getGroups().isEmpty()) {
+            return;
+          }
+          audioTrackChecked = true;
+          for (Tracks.Group group : tracks.getGroups()) {
+            if (group.getType() == C.TRACK_TYPE_AUDIO) {
+              return;
+            }
+          }
+          onErrorListener.onError("No audio track for path: " + item.getPath());
+        }
+      });
 
       String path = item.getPath();
       Uri uri = path.startsWith("/") ? Uri.fromFile(new File(path)) : Uri.parse(path);

--- a/android/src/main/java/com/azzapp/rnskv/VideoComposition.java
+++ b/android/src/main/java/com/azzapp/rnskv/VideoComposition.java
@@ -27,6 +27,15 @@ public class VideoComposition {
     return duration;
   }
 
+  public boolean hasAudio() {
+    for (Item item : items) {
+      if (item.isAudioEnabled()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   public static class Item {
     private String id;
     private String path;
@@ -35,6 +44,9 @@ public class VideoComposition {
     private double duration;
     private int width = -1;
     private int height = -1;
+    private boolean isVideo = true;
+    private boolean audioEnabled = false;
+    private double audioVolume = 1.0;
 
     public Item() {
     }
@@ -79,6 +91,18 @@ public class VideoComposition {
 
     public int getHeight() {
       return height;
+    }
+
+    public boolean isVideo() {
+      return isVideo;
+    }
+
+    public boolean isAudioEnabled() {
+      return audioEnabled;
+    }
+
+    public double getAudioVolume() {
+      return audioVolume;
     }
   }
 }

--- a/android/src/main/java/com/azzapp/rnskv/VideoCompositionDecoder.java
+++ b/android/src/main/java/com/azzapp/rnskv/VideoCompositionDecoder.java
@@ -38,6 +38,9 @@ public class VideoCompositionDecoder {
     decoders = new HashMap<>();
     glFrameExtractors = new HashMap<>();
     composition.getItems().forEach(item -> {
+      if (!item.isVideo()) {
+        return;
+      }
       VideoCompositionItemDecoder decoder = new VideoCompositionItemDecoder(item);
       decoder.setOnErrorListener(error -> {
         if (onErrorListener != null) {
@@ -150,6 +153,9 @@ public class VideoCompositionDecoder {
    */
   public Map<String, VideoFrame> updateVideosFrames() {
     for (VideoComposition.Item item : composition.getItems()) {
+      if (!item.isVideo()) {
+        continue;
+      }
       GLFrameExtractor glFrameExtractor = glFrameExtractors.get(item);
       VideoCompositionItemDecoder decoder = decoders.get(item);
       if (eglResourcesHolder == null || glFrameExtractor == null || decoder == null) {

--- a/android/src/main/java/com/azzapp/rnskv/VideoCompositionFramesExtractor.java
+++ b/android/src/main/java/com/azzapp/rnskv/VideoCompositionFramesExtractor.java
@@ -52,6 +52,7 @@ public class VideoCompositionFramesExtractor {
   private long startTime = 0;
   private long pausePosition = 0;
   private boolean isEOS = false;
+  private boolean completeDispatched = false;
 
   /**
    * Create a new VideoCompositionFramesExtractor.
@@ -152,6 +153,8 @@ public class VideoCompositionFramesExtractor {
     decoder.start();
     if (composition.hasAudio()) {
       audioPlayer = new AudioCompositionPlayer(composition);
+      audioPlayer.setOnErrorListener(
+        message -> eventDispatcher.dispatchEvent("error", message));
       audioPlayer.prepare();
     }
     prepared = true;
@@ -199,10 +202,15 @@ public class VideoCompositionFramesExtractor {
 
     isEOS = currentPosition >= TimeHelpers.secToUs(composition.getDuration());
     if (isEOS) {
-      eventDispatcher.dispatchEvent("complete", null);
+      if (!completeDispatched) {
+        completeDispatched = true;
+        eventDispatcher.dispatchEvent("complete", null);
+      }
       isPlaying = false;
       pausePosition = TimeHelpers.secToUs(composition.getDuration());
       currentPosition = pausePosition;
+    } else {
+      completeDispatched = false;
     }
     decoder.render(currentPosition);
     if (isEOS && looping) {

--- a/android/src/main/java/com/azzapp/rnskv/VideoCompositionFramesExtractor.java
+++ b/android/src/main/java/com/azzapp/rnskv/VideoCompositionFramesExtractor.java
@@ -250,8 +250,6 @@ public class VideoCompositionFramesExtractor {
       try {
         audioPlayer.release();
       } catch (Exception e) {
-        // the video decoders must be released no matter what, leaking them
-        // would prevent any further composition player from being created.
         Log.w(TAG, "Could not release the audio players", e);
       }
       audioPlayer = null;

--- a/android/src/main/java/com/azzapp/rnskv/VideoCompositionFramesExtractor.java
+++ b/android/src/main/java/com/azzapp/rnskv/VideoCompositionFramesExtractor.java
@@ -7,6 +7,8 @@ import android.os.Process;
 import android.os.SystemClock;
 import android.util.Log;
 
+import androidx.media3.common.util.UnstableApi;
+
 import java.io.IOException;
 import java.util.Map;
 import javax.microedition.khronos.egl.EGLContext;
@@ -14,6 +16,7 @@ import javax.microedition.khronos.egl.EGLContext;
 /**
  * A class that previews a video composition.
  */
+@UnstableApi
 public class VideoCompositionFramesExtractor {
   private static final String TAG = "VideoCompositionFramesExtractor";
 
@@ -27,6 +30,8 @@ public class VideoCompositionFramesExtractor {
   private final VideoComposition composition;
 
   private final VideoCompositionDecoder decoder;
+
+  private AudioCompositionPlayer audioPlayer;
 
   private final PlaybackThread playbackThread;
 
@@ -145,6 +150,10 @@ public class VideoCompositionFramesExtractor {
 
   private void prepareInternal() {
     decoder.start();
+    if (composition.hasAudio()) {
+      audioPlayer = new AudioCompositionPlayer(composition);
+      audioPlayer.prepare();
+    }
     prepared = true;
     eventDispatcher.dispatchEvent("ready", null);
     handler.sendEmptyMessage(PLAYBACK_LOOP);
@@ -178,6 +187,9 @@ public class VideoCompositionFramesExtractor {
     }
     pausePosition = getCurrentPosition();
     isPlaying = false;
+    if (audioPlayer != null) {
+      audioPlayer.pause();
+    }
   }
 
   private void loopInternal() throws IOException, InterruptedException {
@@ -196,6 +208,9 @@ public class VideoCompositionFramesExtractor {
     if (isEOS && looping) {
       playInternal();
     }
+    if (audioPlayer != null) {
+      audioPlayer.update(getCurrentPosition(), isPlaying);
+    }
     long delay = 10;
     long duration = (SystemClock.elapsedRealtime() - loopStartTime);
     delay = delay - duration;
@@ -212,6 +227,9 @@ public class VideoCompositionFramesExtractor {
       return;
     }
     decoder.seekTo(position);
+    if (audioPlayer != null) {
+      audioPlayer.seekTo(position);
+    }
     if (isPlaying) {
       startTime = microTime() - position;
     } else {
@@ -220,6 +238,10 @@ public class VideoCompositionFramesExtractor {
   }
 
   private void releaseInternal() {
+    if (audioPlayer != null) {
+      audioPlayer.release();
+      audioPlayer = null;
+    }
     playbackThread.interrupt();
     playbackThread.quit();
     decoder.release();

--- a/android/src/main/java/com/azzapp/rnskv/VideoCompositionFramesExtractor.java
+++ b/android/src/main/java/com/azzapp/rnskv/VideoCompositionFramesExtractor.java
@@ -247,7 +247,13 @@ public class VideoCompositionFramesExtractor {
 
   private void releaseInternal() {
     if (audioPlayer != null) {
-      audioPlayer.release();
+      try {
+        audioPlayer.release();
+      } catch (Exception e) {
+        // the video decoders must be released no matter what, leaking them
+        // would prevent any further composition player from being created.
+        Log.w(TAG, "Could not release the audio players", e);
+      }
       audioPlayer = null;
     }
     playbackThread.interrupt();

--- a/android/src/main/java/com/azzapp/rnskv/VideoCompositionFramesExtractorSync.java
+++ b/android/src/main/java/com/azzapp/rnskv/VideoCompositionFramesExtractorSync.java
@@ -103,6 +103,9 @@ public class VideoCompositionFramesExtractorSync {
   private void checkIfFrameDecoded() {
     boolean allItemsReady = true;
     for (VideoComposition.Item item : composition.getItems()) {
+      if (!item.isVideo()) {
+        continue;
+      }
       if (!itemsTimes.containsKey(item)) {
         allItemsReady = false;
         continue;
@@ -147,6 +150,9 @@ public class VideoCompositionFramesExtractorSync {
   private void resolveIfReady() {
     Map<String, VideoFrame> videoFrames = decoder.updateVideosFrames();
     for (VideoComposition.Item item : composition.getItems()) {
+      if (!item.isVideo()) {
+        continue;
+      }
       VideoFrame videoFrame = videoFrames.getOrDefault(item.getId(), null);
       if (videoFrame == null) {
         return;

--- a/android/src/main/java/com/azzapp/rnskv/VideoEncoder.java
+++ b/android/src/main/java/com/azzapp/rnskv/VideoEncoder.java
@@ -193,6 +193,12 @@ public class VideoEncoder {
   }
 
   public void encodeFrame(int texture, double time) {
+    // Fail fast if the audio pipeline died: the muxer cannot start without
+    // the audio track and every video sample would pile up in
+    // pendingVideoSamples until the end of the export.
+    if (audioException != null) {
+      throw new RuntimeException("Could not encode composition audio", audioException);
+    }
     long timeUS = TimeHelpers.secToUs(time);
     GLES20.glClearColor(0, 0, 0, 0);
     GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT);

--- a/android/src/main/java/com/azzapp/rnskv/VideoEncoder.java
+++ b/android/src/main/java/com/azzapp/rnskv/VideoEncoder.java
@@ -11,13 +11,16 @@ import android.view.Surface;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.microedition.khronos.egl.EGL10;
 import javax.microedition.khronos.egl.EGLContext;
 
 
 /**
- * Helper class for encoding video.
+ * Helper class for encoding video (and the audio of the composition items,
+ * if any).
  */
 public class VideoEncoder {
 
@@ -39,6 +42,16 @@ public class VideoEncoder {
 
   private final String encoderName;
 
+  private final VideoComposition composition;
+
+  private final int audioSampleRate;
+
+  private final int audioChannelCount;
+
+  private final int audioBitRate;
+
+  private final boolean hasAudio;
+
   private MediaCodec encoder;
 
   private Surface inputSurface;
@@ -51,10 +64,21 @@ public class VideoEncoder {
 
   private int trackIndex;
 
+  private int audioTrackIndex;
+
   private boolean muxerStarted;
 
   private final MediaCodec.BufferInfo bufferInfo;
 
+  private Thread audioThread;
+
+  private volatile boolean audioCanceled = false;
+
+  private volatile Exception audioException;
+
+  private final List<PendingSample> pendingVideoSamples = new ArrayList<>();
+
+  private final List<PendingSample> pendingAudioSamples = new ArrayList<>();
 
   /**
    * Creates a new VideoEncoder.
@@ -65,6 +89,11 @@ public class VideoEncoder {
    * @param frameRate  the frame rate of the video
    * @param bitRate    the bit rate of the video
    * @param encoderName the name of the encoder to use, or null to use the default encoder
+   * @param composition the composition being exported, used to encode the
+   *                    audio of its audio-enabled items; can be null
+   * @param audioSampleRate the sample rate of the exported audio track
+   * @param audioChannelCount the number of channels of the exported audio track
+   * @param audioBitRate the bit rate of the exported audio track
    */
   public VideoEncoder(
     String outputPath,
@@ -72,7 +101,11 @@ public class VideoEncoder {
     int height,
     int frameRate,
     int bitRate,
-    String encoderName
+    String encoderName,
+    VideoComposition composition,
+    int audioSampleRate,
+    int audioChannelCount,
+    int audioBitRate
   ) {
     this.outputPath = outputPath;
     this.width = width;
@@ -80,6 +113,11 @@ public class VideoEncoder {
     this.frameRate = frameRate;
     this.bitRate = bitRate;
     this.encoderName = encoderName;
+    this.composition = composition;
+    this.audioSampleRate = audioSampleRate;
+    this.audioChannelCount = audioChannelCount;
+    this.audioBitRate = audioBitRate;
+    this.hasAudio = composition != null && composition.hasAudio();
     bufferInfo = new MediaCodec.BufferInfo();
   }
 
@@ -114,7 +152,40 @@ public class VideoEncoder {
     }
 
     trackIndex = -1;
+    audioTrackIndex = -1;
     muxerStarted = false;
+
+    if (hasAudio) {
+      AudioCompositionExporter audioExporter = new AudioCompositionExporter(
+        composition,
+        audioSampleRate,
+        audioChannelCount,
+        audioBitRate,
+        new AudioCompositionExporter.Sink() {
+          @Override
+          public void onAudioFormat(MediaFormat format) {
+            synchronized (VideoEncoder.this) {
+              audioTrackIndex = muxer.addTrack(format);
+              maybeStartMuxer();
+            }
+          }
+
+          @Override
+          public void onAudioSample(ByteBuffer buffer, MediaCodec.BufferInfo info) {
+            writeOrQueueSample(false, buffer, info);
+          }
+        },
+        () -> audioCanceled
+      );
+      audioThread = new Thread(() -> {
+        try {
+          audioExporter.run();
+        } catch (Exception e) {
+          audioException = e;
+        }
+      }, "ReactNativeSkiaVideo-AudioExportThread");
+      audioThread.start();
+    }
   }
 
   public void makeGLContextCurrent() {
@@ -136,6 +207,71 @@ public class VideoEncoder {
 
   public void finishWriting() {
     drainEncoder(true);
+    if (audioThread != null) {
+      try {
+        audioThread.join();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException("Interrupted while writing audio", e);
+      }
+      audioThread = null;
+      if (audioException != null) {
+        throw new RuntimeException("Could not encode composition audio", audioException);
+      }
+    }
+  }
+
+  /**
+   * Starts the muxer once every track has been registered and flushes the
+   * queued samples. Must be called with the monitor held.
+   */
+  private void maybeStartMuxer() {
+    if (muxerStarted
+      || trackIndex < 0
+      || (hasAudio && audioTrackIndex < 0)) {
+      return;
+    }
+    muxer.start();
+    muxerStarted = true;
+    for (PendingSample sample : pendingVideoSamples) {
+      muxer.writeSampleData(trackIndex, sample.buffer, sample.bufferInfo);
+    }
+    pendingVideoSamples.clear();
+    for (PendingSample sample : pendingAudioSamples) {
+      muxer.writeSampleData(audioTrackIndex, sample.buffer, sample.bufferInfo);
+    }
+    pendingAudioSamples.clear();
+  }
+
+  /**
+   * Writes a sample to the muxer, or queues it until the muxer has started.
+   */
+  private synchronized void writeOrQueueSample(
+    boolean isVideo,
+    ByteBuffer buffer,
+    MediaCodec.BufferInfo info
+  ) {
+    if (muxerStarted) {
+      muxer.writeSampleData(isVideo ? trackIndex : audioTrackIndex, buffer, info);
+      return;
+    }
+    ByteBuffer copy = ByteBuffer.allocateDirect(info.size);
+    copy.put(buffer);
+    copy.flip();
+    MediaCodec.BufferInfo infoCopy = new MediaCodec.BufferInfo();
+    infoCopy.set(0, info.size, info.presentationTimeUs, info.flags);
+    (isVideo ? pendingVideoSamples : pendingAudioSamples)
+      .add(new PendingSample(copy, infoCopy));
+  }
+
+  private static class PendingSample {
+    final ByteBuffer buffer;
+    final MediaCodec.BufferInfo bufferInfo;
+
+    PendingSample(ByteBuffer buffer, MediaCodec.BufferInfo bufferInfo) {
+      this.buffer = buffer;
+      this.bufferInfo = bufferInfo;
+    }
   }
 
   /**
@@ -160,15 +296,13 @@ public class VideoEncoder {
       }
       if (encoderStatus == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
         // should happen before receiving buffers, and should only happen once
-        if (muxerStarted) {
+        if (trackIndex >= 0) {
           throw new RuntimeException("format changed twice");
         }
-        MediaFormat newFormat = encoder.getOutputFormat();
-
-        // now that we have the Magic Goodies, start the muxer
-        trackIndex = muxer.addTrack(newFormat);
-        muxer.start();
-        muxerStarted = true;
+        synchronized (this) {
+          trackIndex = muxer.addTrack(encoder.getOutputFormat());
+          maybeStartMuxer();
+        }
       } else if (encoderStatus < 0) {
         Log.w(TAG, "unexpected result from encoder.dequeueOutputBuffer: " + encoderStatus);
         // let's ignore it
@@ -185,15 +319,11 @@ public class VideoEncoder {
         }
 
         if (bufferInfo.size != 0) {
-          if (!muxerStarted) {
-            throw new RuntimeException("muxer hasn't started");
-          }
-
           // adjust the ByteBuffer values to match BufferInfo (not needed?)
           encodedData.position(bufferInfo.offset);
           encodedData.limit(bufferInfo.offset + bufferInfo.size);
 
-          muxer.writeSampleData(trackIndex, encodedData, bufferInfo);
+          writeOrQueueSample(true, encodedData, bufferInfo);
         }
 
         encoder.releaseOutputBuffer(encoderStatus, false);
@@ -212,6 +342,16 @@ public class VideoEncoder {
    * Releases encoder resources.  May be called after partial / failed initialization.
    */
   public void release() {
+    if (audioThread != null) {
+      // Stop the audio pipeline before tearing down the muxer.
+      audioCanceled = true;
+      try {
+        audioThread.join(5000);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      audioThread = null;
+    }
     if (eglResourcesHolder != null) {
       eglResourcesHolder.release();
     }
@@ -225,7 +365,12 @@ public class VideoEncoder {
       inputSurface = null;
     }
     if (muxer != null) {
-      muxer.stop();
+      try {
+        muxer.stop();
+      } catch (IllegalStateException e) {
+        // the muxer never started or has no sample (failed exports).
+        Log.w(TAG, "Could not stop the muxer", e);
+      }
       muxer.release();
       muxer = null;
     }

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -17,8 +17,6 @@ GEM
       json (>= 1.5.1)
     atomos (0.1.3)
     base64 (0.2.0)
-    benchmark (0.1.0)
-    bigdecimal (2.0.0)
     claide (1.1.0)
     cocoapods (1.14.3)
       addressable (~> 2.8)
@@ -70,10 +68,8 @@ GEM
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     json (2.7.2)
-    logger (1.4.2)
     minitest (5.22.3)
     molinillo (0.8.0)
-    mutex_m (0.1.0)
     nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
@@ -98,14 +94,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (>= 6.1.7.5, != 7.1.0)
-  benchmark
-  bigdecimal
   cocoapods (>= 1.13, != 1.15.1, != 1.15.0)
-  concurrent-ruby (< 1.3.4)
-  logger
-  mutex_m
-  nkf
-  xcodeproj (< 1.26.0)
 
 RUBY VERSION
    ruby 2.7.6p219

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -17,6 +17,8 @@ GEM
       json (>= 1.5.1)
     atomos (0.1.3)
     base64 (0.2.0)
+    benchmark (0.1.0)
+    bigdecimal (2.0.0)
     claide (1.1.0)
     cocoapods (1.14.3)
       addressable (~> 2.8)
@@ -68,8 +70,10 @@ GEM
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     json (2.7.2)
+    logger (1.4.2)
     minitest (5.22.3)
     molinillo (0.8.0)
+    mutex_m (0.1.0)
     nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
@@ -94,7 +98,14 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (>= 6.1.7.5, != 7.1.0)
+  benchmark
+  bigdecimal
   cocoapods (>= 1.13, != 1.15.1, != 1.15.0)
+  concurrent-ruby (< 1.3.4)
+  logger
+  mutex_m
+  nkf
+  xcodeproj (< 1.26.0)
 
 RUBY VERSION
    ruby 2.7.6p219

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1449,7 +1449,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-blob-util (0.24.10):
+  - react-native-blob-util (0.24.9):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2481,90 +2481,90 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  azzapp-react-native-skia-video: f916e156fcfa43070a7c62db18556becabee7896
+  azzapp-react-native-skia-video: 731f9e32fffbebed2494ea0c474c61d6012f9473
   FBLazyVector: 3c3be9a019176b5699455f7f66c5444b78a411c6
   hermes-engine: 23b753613897f88a4302abcd1421afdc1f7a2f44
   RCTDeprecation: bccb6545c26db881ecddfd83a3f9ea82aba1605f
   RCTRequired: b2f74764d596fc0051f00fee94b49bf41a6f7f5a
   RCTSwiftUI: c6d6a31b849b9dfa64c33b55dc91ac15dd55774c
-  RCTSwiftUIWrapper: bdff268d65d662a79b1e571e841e1512275f9319
+  RCTSwiftUIWrapper: 0106c38ccc929e3b2f8815c50ab873e345ab2777
   RCTTypeSafety: 159e394bdab42023fbdd8fa022dfdc5577a8b9ad
   React: 4b2532a459d15e1adf6c22d3e399e5c85a94220f
   React-callinvoker: 0b8ce4057e02a0bd15cf0532596e8eb8c0392e92
-  React-Core: 5af045531a540ba3f65f07de1e3f585ddfb27948
+  React-Core: 52b990bb36640833e636d5efc817ad4700dd7f93
   React-Core-prebuilt: 405cf395d66cf694faf9aed3483a21b5515cec85
-  React-CoreModules: 99b194a721de84ccfc1be149a0de52647dc38c0e
-  React-cxxreact: b7e8e254074fd8111d147202b391ccf7816946a6
+  React-CoreModules: 43516d84b3851a850a835d32ec740db319e7bf9e
+  React-cxxreact: 9254233b543b9f49bdbcad329603e70be5582a0e
   React-debug: 6bc17013f4dc724c23c91e1c83220251d1eacee6
-  React-defaultsnativemodule: aec0c526e254a5ce43c79fecb83123f4aecd4199
-  React-domnativemodule: edd8f47d850a7d3fae0626b624a669e8a9e40f21
-  React-Fabric: a3b0ce70506ac2e737b9cd6667877382f2ee2f29
-  React-FabricComponents: 18bf172f8dc2308cb93c539713a3ac778192e225
-  React-FabricImage: 260ea6794cb5d08aacc0f591110bbf66dfc3ed80
-  React-featureflags: 828f711206ab1a3aa0ec40f39d9f7f793352489d
-  React-featureflagsnativemodule: cc62b7be20aa1e76efde77550dbc34db8556d604
-  React-graphics: 9a9fa8dd605d210a43d88e7d4c78bfff544b09ad
-  React-hermes: 6fd579ceeb680830fc508697acdd5e8cd8dbf29f
-  React-idlecallbacksnativemodule: af59e31212470464d6e6fda0f6cc7e5c413b5d29
-  React-ImageManager: 5c97e7ce5c37335c0392f629daba4c2143f0be2f
-  React-intersectionobservernativemodule: ea5682b04b6cff32fe57d5f0f530f07c33a55b34
-  React-jserrorhandler: baa4284f642fd0cbcf7664860abe7e18e54d05de
-  React-jsi: 7b14065a285f91b3dbe5448371ff575bbb523d59
-  React-jsiexecutor: 10b4ba40ec9fd571370dfee20251201f57712e79
-  React-jsinspector: ec4602cc56d9ec4c7789017a51a639052d4642e0
-  React-jsinspectorcdp: 46a17a5e80e4c84e734ba9cbc8fe4efaa496722a
-  React-jsinspectornetwork: a6743d072cb0e383de2b9bc7ddc4c824e617c681
-  React-jsinspectortracing: 24b2dd80722ef691af02d4aa6a1e32e1f61d9bfb
-  React-jsitooling: e483e01f15f2b11d8f5317372de762deaff4dcd9
-  React-jsitracing: db1285e61be69980443ca27e4f8dea36f8a3b906
-  React-logger: 35ab012027cc552057f7ca5d031c6721f896e6bc
-  React-Mapbuffer: 44dd007f917e2396afa0e70bbd70273237d93fde
-  React-microtasksnativemodule: f413ee411341fb3c34d20e85e9f6f524921fab15
-  React-mutationobservernativemodule: 58f6d2adf7d98e72b241608dfa2ddce414d2a4e7
-  react-native-blob-util: 13e70f811eb34f14864622c4afa37cc20fe8100e
-  react-native-safe-area-context: fb5c8ee9f6dd62ef710611b3d370c501f42a4ac0
-  react-native-skia: 599df5d4bece61f5ae0bdf2d08d45a83ac1b01a7
-  react-native-slider: 08ecfc4e9cc16cc388a56dd9caeca51b55cd9bb7
-  React-NativeModulesApple: 167e532fb9bae30f3c66636b8ee0092bab263667
-  React-networking: 89f6b69755a3176f30e56ba1ba8e214b1518ecfb
+  React-defaultsnativemodule: deed608618274d6b9e395d0bb91925ec1384c827
+  React-domnativemodule: 8a7604a27a33d0b7ea3acd6ef5e556935af506a2
+  React-Fabric: e4f68a49e82aeb25e1f144d50ffa32dfb629cf16
+  React-FabricComponents: 7326b9ae2c2162033ba1d10713a2a6b0e762a990
+  React-FabricImage: e84692d44ac1a1c1560e86fad772449a033ef327
+  React-featureflags: 78f3d05ae8cbcfc3e26524954516fd1f8307d0ab
+  React-featureflagsnativemodule: c4f65ff56d5435db590214243e47cfdfdb7cf828
+  React-graphics: 394bd9e1311370733f770af9ba389e07e069a5d0
+  React-hermes: 9f44a83eca48842bd3f60fdc16bdb4fa29105eae
+  React-idlecallbacksnativemodule: 0ea88c4d02c347b18d8767bc85bda53e4d4821e8
+  React-ImageManager: 511d829cde144ba19a9b81007d1c44857d35c23e
+  React-intersectionobservernativemodule: 6fbd27810c75eac0beb09ea6b4d6fa8affd3c2d8
+  React-jserrorhandler: 695c432fcac6469bdfc28448a6315f84b58b18ec
+  React-jsi: 40bd06de577b224175f2ce5b4eb2cffa449c86df
+  React-jsiexecutor: 0c6068034234dd6910fa6d82f378f75bcc02a8b7
+  React-jsinspector: f1d093a0bc5cceb0c2d70a795208faf78135b4f9
+  React-jsinspectorcdp: 715b446a0e94cff9b3ee39131b39a58d707e96c5
+  React-jsinspectornetwork: 9c7351b59a5c05d095d797de8c5ad02f2e6e454c
+  React-jsinspectortracing: 464f0c731f7e9bb315073a1c3ea580feec29a07f
+  React-jsitooling: 08d95836603e386299044c72ce55a9e5ccd33be3
+  React-jsitracing: 3be389b754562dac073e4c167a010b9a91955417
+  React-logger: de0bd725e905e9be3ab919a4206666eec7c3e248
+  React-Mapbuffer: bfc59384f088a74c1cbe31902b5ba3d89c5947ce
+  React-microtasksnativemodule: 4e4a0a4e42861c767989099d02cd871dbe11736f
+  React-mutationobservernativemodule: 6aaa67618b68a616b1293967c20a1dfcc26632a5
+  react-native-blob-util: 02af0db0257fb4dc980de04602103e1c26ce6180
+  react-native-safe-area-context: c1eb308f4b36372a4de4b3bdaa8ed695ec3dd461
+  react-native-skia: 6102d874ee6e0b3c0e3d68896ea9c5b77f4e90d0
+  react-native-slider: 8824cf332b11bf5149f6576c8c8b32b4f93f82ac
+  React-NativeModulesApple: f313ed47b56405d621e12ecda106a72020959ff3
+  React-networking: a0686d5a80eddbcd7bb702421fca503a76aacb1a
   React-oscompat: db6675ddaef3bddd1b41533627f3d26ec710c05f
-  React-perflogger: c34660c72849d23319f5e544c97e6c6ed687b186
-  React-performancecdpmetrics: 13ce0ca13d32007b7369f295c81bfad6316514bc
-  React-performancetimeline: b68271d5199dc356a80b661bb05622f5ed6777fb
+  React-perflogger: 21ca12b8deb8411c6fa4a564e6e4e0800390b556
+  React-performancecdpmetrics: 8497263114d72822f737e0b78aad26c85b2099bf
+  React-performancetimeline: bb4ca5f73f04b1074d2fe35dd574f30e58fbd733
   React-RCTActionSheet: 7d18777c531c516ab9f86342583057b15fb7fd7d
-  React-RCTAnimation: f2505067d2d83268f5619192f8f5ff14b2606c7f
-  React-RCTAppDelegate: 7bfa4d752f45a0b9195b8da0f188f8904806a86f
-  React-RCTBlob: 7b4d25eca2a6ecd83766d76790879774b73b4cd5
-  React-RCTFabric: a225895f3fd2b11f2c44b13229f2d99065eedda1
-  React-RCTFBReactNativeSpec: cb15356d207d325e689eca0c7b15d737aac8c6dc
-  React-RCTImage: 9123b010921479b5bcd3771a4a4d4e788227a427
-  React-RCTLinking: 358d42629d7012c5d75060fd3e25023b72ebae31
-  React-RCTNetwork: 32f5274abd61e937bdcbfd85810ae784d3f0e38a
-  React-RCTRuntime: b11ef93babc2be36f5e10835d246e0e623f6570b
-  React-RCTSettings: 86aa6e6a3a335d989e3fcd1bd98b9ea6331adfa9
-  React-RCTText: 59376611225f3c6fdc75d57571d7c345bdd0be1e
-  React-RCTVibration: 3c7d17d3373c114220be9ac3b99df1646009b8fe
+  React-RCTAnimation: 14a2fdc1165d73dc96abd0935e89c2127a119fbd
+  React-RCTAppDelegate: 0b5a06df526fe79b2a5cbe90b889e28867e14574
+  React-RCTBlob: f2ebb238c43a631f541377ec18ed60bb70665363
+  React-RCTFabric: 231d533ee1d4eb9db9f876ad8c25878794b53724
+  React-RCTFBReactNativeSpec: 679afd98830c2cb6cb7a0c31763012cbc74fa486
+  React-RCTImage: 1d8c5b8786a0f52d0d2613b8ba58c02c1da67c1e
+  React-RCTLinking: 2560d59e85c82f260bff81fffc4ea30bc66a500b
+  React-RCTNetwork: d331a823911e70fd1de7eeddaa739f4c54dcacc4
+  React-RCTRuntime: b1cc28447a887ac6f1b1d383d93d1f9360b1b6e8
+  React-RCTSettings: b7896598aa87af4b907628164240e87457e6f830
+  React-RCTText: 1eb82d0798487adcf394a12d8fad825722d1a376
+  React-RCTVibration: 0c76a15901bb1c8d47a8a02dc16f95f39ed3ffb5
   React-rendererconsistency: c9a2d2351407696ccbefdeb53b4aee109c4cb008
-  React-renderercss: 883aebdf574736450571800eeb3edbc804385c76
-  React-rendererdebug: fc1e330efedfd4dfe4fd7d75736f9a219dae196f
-  React-RuntimeApple: f099a47224222ddfc7ddaffdd9aa2ac47a216ee0
-  React-RuntimeCore: e91b17661cc543f4a241e69b3f038182d7db8fd6
-  React-runtimeexecutor: d27e321bd8e04d4737bc8924473a25defb33a031
-  React-RuntimeHermes: 760a0793748cb12b4dd11f323bd516668b7e3b99
-  React-runtimescheduler: df1c84ed1a5b78a1a7953d3e86db6163c4542906
-  React-timing: 791690a2daa7b13554060f6836c260c8bc311a98
-  React-utils: 13f4f227561d2660201dee5cbea253c07d8b5d3a
-  React-viewtransitionnativemodule: 93335dacae2dd7db207320f384111c2b4c58fca8
-  React-webperformancenativemodule: 0bed183d6447493571431c031ad2401c027b5866
-  ReactAppDependencyProvider: 0e13d430eadac8a2ef18515a860d5c59df05b475
-  ReactCodegen: 3bbb7de19774794a7428ef623a7b777106cf3737
-  ReactCommon: 9002f006f571256348994183f7d4387aa7cf84e8
+  React-renderercss: f47a328de59fa4f6a86900e9c57533aae3a9c02f
+  React-rendererdebug: d160cfa801014fb69206f0b4cde4c1e78805b766
+  React-RuntimeApple: bdfe33451e5ad94bb6cda9f259da6682f0da2e83
+  React-RuntimeCore: 5924b98279f2729b50b34a59f379d8bdd66425e6
+  React-runtimeexecutor: 1d8152478961e2eba5137d6cfeaf44037e84974d
+  React-RuntimeHermes: 93211f1da41bee7a5a5b4095b47504beffae98de
+  React-runtimescheduler: 4cd060f43d1bfb03b30ad876925e018ca0f89f0e
+  React-timing: 3e175c2d74410262027458380950122a18b1edf0
+  React-utils: 9e3bc5d5f28e4333605df0d6cd5873ea29936715
+  React-viewtransitionnativemodule: 6958f31ac3ed27ccb4da3446d4041da111b63949
+  React-webperformancenativemodule: a52e599962a9be3c06ed00470e71e3c3d94f942f
+  ReactAppDependencyProvider: 082ef199e27011a4314f499b6b2e2ac29e141267
+  ReactCodegen: bb259ec28a456704be0a3485e93096a497a29917
+  ReactCommon: 00d8d68c7aa036745334d3a3844102ecd9bf099d
   ReactNativeDependencies: 2bd6854ade79bf1b60586d1ab7813a389df1b6bf
-  RNReanimated: 5aa9e73d0f8d3c40d5c9bec396d6a61098db31f0
-  RNScreens: 7118cd7715c226856125b5bece3c4d9abec90356
-  RNWorklets: 9052122d7f98de547d247e775ea2069839236d38
-  Yoga: 9891cfb1c680f64de9c41b09e7453dea33454d2b
+  RNReanimated: 5cc36a25f9e60c523734a60783f84d363e73b4dc
+  RNScreens: dcd5c85a822d9cbb21fc321bbbbcf918f3d48c23
+  RNWorklets: 7ed4f7041bd561c13fe502161eca6e907049526d
+  Yoga: 8cf9dd9fc7761e176a3361b4821d26d11cfbeab1
 
 PODFILE CHECKSUM: e42769fbb547a8c4c9c22514cc1a46d3c80e2235
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.14.3

--- a/example/src/VideoCompositionExample.tsx
+++ b/example/src/VideoCompositionExample.tsx
@@ -167,10 +167,10 @@ const PexelsVideoPicker = ({
   );
 };
 
-// Public domain recording: "E lucevan le stelle" (Tosca, Puccini)
-// sung by Enrico Caruso, 1909.
+// CC0 studio recording: Bach, Goldberg Variations "Aria" (BWV 988)
+// performed by Kimiko Ishizaka (Open Goldberg Variations).
 const MUSIC_URL =
-  'https://archive.org/download/78_e-lucevan-le-stelle_enrico-caruso-puccini_gbia0011420a/E%20Lucevan%20Le%20Stelle%20-%20Enrico%20Caruso%20-%20Puccini.mp3';
+  'https://archive.org/download/OpenGoldbergVariations/Kimiko%20Ishizaka%20-%20J.S.%20Bach-%20-Open-%20Goldberg%20Variations%2C%20BWV%20988%20%28Piano%29%20-%2001%20Aria.mp3';
 
 const drawFrame: FrameDrawer = ({
   videoComposition,
@@ -421,6 +421,7 @@ const VideoCompositionPreview = ({
       }).then(
         () => {
           setExportedPath(outPath);
+          console.log('Video exported to', outPath);
         },
         (error) => {
           Alert.alert('Error exporting video', error.message);

--- a/example/src/VideoCompositionExample.tsx
+++ b/example/src/VideoCompositionExample.tsx
@@ -167,8 +167,6 @@ const PexelsVideoPicker = ({
   );
 };
 
-// CC0 studio recording: Bach, Goldberg Variations "Aria" (BWV 988)
-// performed by Kimiko Ishizaka (Open Goldberg Variations).
 const MUSIC_URL =
   'https://archive.org/download/OpenGoldbergVariations/Kimiko%20Ishizaka%20-%20J.S.%20Bach-%20-Open-%20Goldberg%20Variations%2C%20BWV%20988%20%28Piano%29%20-%2001%20Aria.mp3';
 
@@ -433,6 +431,14 @@ const VideoCompositionPreview = ({
 
   const { width: windowWidth } = useWindowDimensions();
 
+  const onPlayerError = useCallback((error: any, retry: () => void) => {
+    console.error('Composition player error:', error);
+    Alert.alert('Composition player error', String(error?.message ?? error), [
+      { text: 'Retry', onPress: retry },
+      { text: 'Cancel' },
+    ]);
+  }, []);
+
   const { currentFrame, player } = useVideoCompositionPlayer({
     composition: exporting ? null : videoComposition,
     autoPlay: true,
@@ -440,6 +446,7 @@ const VideoCompositionPreview = ({
     drawFrame,
     width: windowWidth,
     height: windowWidth,
+    onError: onPlayerError,
   });
 
   const [isPlaying, setIsPlaying] = useState(true);

--- a/example/src/VideoCompositionExample.tsx
+++ b/example/src/VideoCompositionExample.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import pexelsClient from './helpers/pexelsClient';
 import type { Video } from 'pexels';
 import {
@@ -13,6 +13,7 @@ import {
   Text,
   Platform,
   Alert,
+  Switch,
 } from 'react-native';
 import {
   createNativeStackNavigator,
@@ -166,6 +167,11 @@ const PexelsVideoPicker = ({
   );
 };
 
+// Public domain recording: "E lucevan le stelle" (Tosca, Puccini)
+// sung by Enrico Caruso, 1909.
+const MUSIC_URL =
+  'https://archive.org/download/78_e-lucevan-le-stelle_enrico-caruso-puccini_gbia0011420a/E%20Lucevan%20Le%20Stelle%20-%20Enrico%20Caruso%20-%20Puccini.mp3';
+
 const drawFrame: FrameDrawer = ({
   videoComposition,
   canvas,
@@ -177,6 +183,7 @@ const drawFrame: FrameDrawer = ({
   'worklet';
   const items = videoComposition.items.filter(
     (item) =>
+      item.kind !== 'audio' &&
       item.compositionStartTime <= currentTime &&
       item.compositionStartTime + item.duration >= currentTime
   );
@@ -248,13 +255,21 @@ const VideoCompositionPreview = ({
     params: { videos },
   },
 }: NativeStackScreenProps<StackParamList, 'PreviewComposition'>) => {
-  const [videoComposition, setVideoComposition] =
+  const [baseComposition, setBaseComposition] =
     useState<VideoComposition | null>(null);
+  const [musicPath, setMusicPath] = useState<string | null>(null);
+  const [musicEnabled, setMusicEnabled] = useState(true);
 
   useEffect(() => {
     const promises: StatefulPromise<any>[] = [];
 
     const fetchFiles = async () => {
+      const musicPromise = ReactNativeBlobUtil.config({
+        fileCache: true,
+        appendExt: 'mp3',
+      }).fetch('GET', MUSIC_URL);
+      promises.push(musicPromise);
+
       const videoUrls: Record<number, StatefulPromise<FetchBlobResponse>> = {};
       for (const video of videos) {
         const uri =
@@ -286,6 +301,13 @@ const VideoCompositionPreview = ({
         }
         return;
       }
+      try {
+        setMusicPath((await musicPromise).path());
+      } catch (error) {
+        if (!(error instanceof ReactNativeBlobUtil.CanceledFetchError)) {
+          console.error(error);
+        }
+      }
       const videoWithFiles = videos
         .map((video) => ({
           ...video,
@@ -307,12 +329,13 @@ const VideoCompositionPreview = ({
             startTime: 0,
             compositionStartTime: currentTime,
             duration,
+            audio: true,
           };
           currentTime += duration - 1;
           return item;
         }),
       };
-      setVideoComposition(composition);
+      setBaseComposition(composition);
     };
 
     fetchFiles();
@@ -323,6 +346,30 @@ const VideoCompositionPreview = ({
       });
     };
   }, [videos]);
+
+  const videoComposition = useMemo<VideoComposition | null>(() => {
+    if (!baseComposition) {
+      return null;
+    }
+    if (!musicEnabled || !musicPath) {
+      return baseComposition;
+    }
+    return {
+      ...baseComposition,
+      items: [
+        ...baseComposition.items,
+        {
+          id: 'music',
+          kind: 'audio',
+          path: musicPath,
+          compositionStartTime: 0,
+          startTime: 0,
+          duration: baseComposition.duration,
+          volume: 0.3,
+        },
+      ],
+    };
+  }, [baseComposition, musicEnabled, musicPath]);
 
   const [exporting, setExporting] = useState(false);
   const [exportedPath, setExportedPath] = useState<string | null>(null);
@@ -470,6 +517,16 @@ const VideoCompositionPreview = ({
                 maximumTrackTintColor={'#CCC'}
                 minimumTrackTintColor={'#F00'}
               />
+              <View
+                style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}
+              >
+                <Text style={{ color: 'black' }}>Background music</Text>
+                <Switch
+                  value={musicEnabled && musicPath != null}
+                  disabled={musicPath == null}
+                  onValueChange={setMusicEnabled}
+                />
+              </View>
               <View
                 style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}
               >

--- a/example/src/VideoCompositionExample.tsx
+++ b/example/src/VideoCompositionExample.tsx
@@ -262,11 +262,16 @@ const VideoCompositionPreview = ({
     const promises: StatefulPromise<any>[] = [];
 
     const fetchFiles = async () => {
-      const musicPromise = ReactNativeBlobUtil.config({
-        fileCache: true,
-        appendExt: 'mp3',
-      }).fetch('GET', MUSIC_URL);
-      promises.push(musicPromise);
+      // The music file is cached at a fixed path so it is only downloaded
+      // on the first visit.
+      const musicFilePath = `${ReactNativeBlobUtil.fs.dirs.CacheDir}/open-goldberg-aria.mp3`;
+      let musicPromise: StatefulPromise<FetchBlobResponse> | null = null;
+      if (!(await ReactNativeBlobUtil.fs.exists(musicFilePath))) {
+        musicPromise = ReactNativeBlobUtil.config({
+          path: musicFilePath,
+        }).fetch('GET', MUSIC_URL);
+        promises.push(musicPromise);
+      }
 
       const videoUrls: Record<number, StatefulPromise<FetchBlobResponse>> = {};
       for (const video of videos) {
@@ -289,8 +294,13 @@ const VideoCompositionPreview = ({
         videoFiles = await Promise.all(
           Object.entries(videoUrls).map(async ([id, promise]) => {
             const response = await promise;
-            const path = response.path();
-            return { id: Number(id), path };
+            const status = response.info().status;
+            if (status !== 200) {
+              throw new Error(
+                `Could not download video ${id} (status ${status})`
+              );
+            }
+            return { id: Number(id), path: response.path() };
           })
         );
       } catch (error) {
@@ -300,8 +310,20 @@ const VideoCompositionPreview = ({
         return;
       }
       try {
-        setMusicPath((await musicPromise).path());
+        if (musicPromise != null) {
+          const musicResponse = await musicPromise;
+          const status = musicResponse.info().status;
+          if (status !== 200) {
+            throw new Error(
+              `Could not download the background music (status ${status})`
+            );
+          }
+        }
+        setMusicPath(musicFilePath);
       } catch (error) {
+        // Remove any partial/invalid file so the next visit retries the
+        // download instead of reusing it.
+        await ReactNativeBlobUtil.fs.unlink(musicFilePath).catch(() => {});
         if (!(error instanceof ReactNativeBlobUtil.CanceledFetchError)) {
           console.error(error);
         }

--- a/example/src/VideoCompositionExample.tsx
+++ b/example/src/VideoCompositionExample.tsx
@@ -262,8 +262,6 @@ const VideoCompositionPreview = ({
     const promises: StatefulPromise<any>[] = [];
 
     const fetchFiles = async () => {
-      // The music file is cached at a fixed path so it is only downloaded
-      // on the first visit.
       const musicFilePath = `${ReactNativeBlobUtil.fs.dirs.CacheDir}/open-goldberg-aria.mp3`;
       let musicPromise: StatefulPromise<FetchBlobResponse> | null = null;
       if (!(await ReactNativeBlobUtil.fs.exists(musicFilePath))) {
@@ -321,8 +319,6 @@ const VideoCompositionPreview = ({
         }
         setMusicPath(musicFilePath);
       } catch (error) {
-        // Remove any partial/invalid file so the next visit retries the
-        // download instead of reusing it.
         await ReactNativeBlobUtil.fs.unlink(musicFilePath).catch(() => {});
         if (!(error instanceof ReactNativeBlobUtil.CanceledFetchError)) {
           console.error(error);
@@ -441,7 +437,6 @@ const VideoCompositionPreview = ({
       }).then(
         () => {
           setExportedPath(outPath);
-          console.log('Video exported to', outPath);
         },
         (error) => {
           Alert.alert('Error exporting video', error.message);

--- a/ios/AudioCompositionUtils.h
+++ b/ios/AudioCompositionUtils.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#import "VideoComposition.h"
+#import <AVFoundation/AVFoundation.h>
+
+namespace RNSkiaVideo {
+
+struct AudioComposition {
+  AVMutableComposition* composition;
+  AVMutableAudioMix* audioMix;
+};
+
+/**
+ * Builds an audio only AVComposition (with an audio mix for per item
+ * volumes) from the audio-enabled items of the given video composition.
+ * Returns {nil, nil} if no item provides audio.
+ * Throws NSError* if an audio item points to a file without audio track.
+ */
+AudioComposition
+buildAudioComposition(const std::shared_ptr<VideoComposition>& composition,
+                      NSMutableDictionary<NSString*, AVURLAsset*>* assetCache);
+
+AVURLAsset*
+getOrCreateAsset(const std::string& path,
+                 NSMutableDictionary<NSString*, AVURLAsset*>* assetCache);
+
+} // namespace RNSkiaVideo

--- a/ios/AudioCompositionUtils.mm
+++ b/ios/AudioCompositionUtils.mm
@@ -1,0 +1,109 @@
+#import "AudioCompositionUtils.h"
+
+namespace RNSkiaVideo {
+
+NS_INLINE NSError* audioErrorWithMessage(NSString* message) {
+  return [NSError errorWithDomain:@"com.azzapp.rnskv"
+                             code:0
+                         userInfo:@{NSLocalizedDescriptionKey : message}];
+}
+
+AVURLAsset*
+getOrCreateAsset(const std::string& path,
+                 NSMutableDictionary<NSString*, AVURLAsset*>* assetCache) {
+  NSString* nsPath =
+      [NSString stringWithCString:path.c_str()
+                         encoding:[NSString defaultCStringEncoding]];
+  AVURLAsset* asset = assetCache ? assetCache[nsPath] : nil;
+  if (!asset) {
+    asset = [AVURLAsset URLAssetWithURL:[NSURL fileURLWithPath:nsPath]
+                                options:nil];
+    if (assetCache) {
+      assetCache[nsPath] = asset;
+    }
+  }
+  return asset;
+}
+
+AudioComposition
+buildAudioComposition(const std::shared_ptr<VideoComposition>& composition,
+                      NSMutableDictionary<NSString*, AVURLAsset*>* assetCache) {
+  AVMutableComposition* audioComposition = [AVMutableComposition composition];
+  NSMutableArray<AVAudioMixInputParameters*>* inputParameters =
+      [NSMutableArray array];
+  bool hasTracks = false;
+  for (const auto& item : composition->items) {
+    if (!item->audioEnabled) {
+      continue;
+    }
+    AVURLAsset* asset = getOrCreateAsset(item->path, assetCache);
+    AVAssetTrack* audioTrack =
+        [[asset tracksWithMediaType:AVMediaTypeAudio] firstObject];
+    if (!audioTrack) {
+      if (!item->isVideo) {
+        throw audioErrorWithMessage(
+            [NSString stringWithFormat:@"No audio track for path: %s",
+                                       item->path.c_str()]);
+      }
+      continue;
+    }
+
+    auto sourceRange = CMTimeRangeGetIntersection(
+        CMTimeRangeMake(CMTimeMakeWithSeconds(item->startTime, NSEC_PER_SEC),
+                        CMTimeMakeWithSeconds(item->duration, NSEC_PER_SEC)),
+        audioTrack.timeRange);
+    if (CMTimeCompare(sourceRange.duration, kCMTimeZero) <= 0) {
+      continue;
+    }
+
+    AVMutableCompositionTrack* compositionTrack = [audioComposition
+        addMutableTrackWithMediaType:AVMediaTypeAudio
+                    preferredTrackID:kCMPersistentTrackID_Invalid];
+    NSError* insertError = nil;
+    if (![compositionTrack
+            insertTimeRange:sourceRange
+                    ofTrack:audioTrack
+                     atTime:CMTimeMakeWithSeconds(item->compositionStartTime,
+                                                  NSEC_PER_SEC)
+                      error:&insertError]) {
+      throw insertError
+          ?: audioErrorWithMessage([NSString
+                 stringWithFormat:@"Could not insert audio track for item: %s",
+                                  item->id.c_str()]);
+    }
+    hasTracks = true;
+
+    if (item->audioVolume != 1.0) {
+      AVMutableAudioMixInputParameters* parameters =
+          [AVMutableAudioMixInputParameters
+              audioMixInputParametersWithTrack:compositionTrack];
+      [parameters setVolume:MAX(0.0, MIN(1.0, item->audioVolume))
+                     atTime:kCMTimeZero];
+      [inputParameters addObject:parameters];
+    }
+  }
+
+  if (!hasTracks) {
+    return {nil, nil};
+  }
+
+  // The playback clock is driven by the audio player: the composition is
+  // padded with silence so the playhead can run the whole timeline and go
+  // past its duration (completion detection).
+  CMTime paddedDuration =
+      CMTimeMakeWithSeconds(composition->duration + 0.5, NSEC_PER_SEC);
+  if (CMTimeCompare(audioComposition.duration, paddedDuration) < 0) {
+    [audioComposition
+        insertEmptyTimeRange:CMTimeRangeFromTimeToTime(
+                                 audioComposition.duration, paddedDuration)];
+  }
+
+  AVMutableAudioMix* audioMix = nil;
+  if (inputParameters.count > 0) {
+    audioMix = [AVMutableAudioMix audioMix];
+    audioMix.inputParameters = inputParameters;
+  }
+  return {audioComposition, audioMix};
+}
+
+} // namespace RNSkiaVideo

--- a/ios/AudioCompositionUtils.mm
+++ b/ios/AudioCompositionUtils.mm
@@ -48,8 +48,9 @@ buildAudioComposition(const std::shared_ptr<VideoComposition>& composition,
       continue;
     }
 
+    CMTime startTime = CMTimeMakeWithSeconds(item->startTime, NSEC_PER_SEC);
     auto sourceRange = CMTimeRangeGetIntersection(
-        CMTimeRangeMake(CMTimeMakeWithSeconds(item->startTime, NSEC_PER_SEC),
+        CMTimeRangeMake(startTime,
                         CMTimeMakeWithSeconds(item->duration, NSEC_PER_SEC)),
         audioTrack.timeRange);
     if (CMTimeCompare(sourceRange.duration, kCMTimeZero) <= 0) {
@@ -59,13 +60,16 @@ buildAudioComposition(const std::shared_ptr<VideoComposition>& composition,
     AVMutableCompositionTrack* compositionTrack = [audioComposition
         addMutableTrackWithMediaType:AVMediaTypeAudio
                     preferredTrackID:kCMPersistentTrackID_Invalid];
+    // If the audio track starts after the requested start time, keep the
+    // offset so the audio stays aligned on the composition timeline.
+    CMTime insertTime = CMTimeAdd(
+        CMTimeMakeWithSeconds(item->compositionStartTime, NSEC_PER_SEC),
+        CMTimeSubtract(sourceRange.start, startTime));
     NSError* insertError = nil;
-    if (![compositionTrack
-            insertTimeRange:sourceRange
-                    ofTrack:audioTrack
-                     atTime:CMTimeMakeWithSeconds(item->compositionStartTime,
-                                                  NSEC_PER_SEC)
-                      error:&insertError]) {
+    if (![compositionTrack insertTimeRange:sourceRange
+                                   ofTrack:audioTrack
+                                    atTime:insertTime
+                                     error:&insertError]) {
       throw insertError
           ?: audioErrorWithMessage([NSString
                  stringWithFormat:@"Could not insert audio track for item: %s",

--- a/ios/RNSVVideoPlayer.mm
+++ b/ios/RNSVVideoPlayer.mm
@@ -393,4 +393,3 @@ static void* rateContext = &rateContext;
 }
 
 @end
-

--- a/ios/ReactNativeSkiaVideo.mm
+++ b/ios/ReactNativeSkiaVideo.mm
@@ -133,10 +133,10 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
                          std::move(createVideoCompositionFramesExtractorSync));
 
   auto createVideoEncoder = jsi::Function::createFromHostFunction(
-      runtime, jsi::PropNameID::forAscii(runtime, "createVideoEncoder"), 1,
+      runtime, jsi::PropNameID::forAscii(runtime, "createVideoEncoder"), 2,
       [](jsi::Runtime& runtime, const jsi::Value& thisValue,
          const jsi::Value* arguments, size_t count) -> jsi::Value {
-        if (count != 1 || !arguments[0].isObject()) {
+        if (count < 1 || !arguments[0].isObject()) {
           throw jsi::JSError(runtime, "ReactNativeSkiaVideo.createVideoEncoder("
                                       "..) expects one arguments (object)!");
         }
@@ -149,9 +149,37 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
         int height = options.getProperty(runtime, "height").asNumber();
         int frameRate = options.getProperty(runtime, "frameRate").asNumber();
         int bitRate = options.getProperty(runtime, "bitRate").asNumber();
+        int audioBitRate = 128000;
+        int audioSampleRate = 44100;
+        int audioChannelCount = 2;
+        if (options.hasProperty(runtime, "audioBitRate")) {
+          auto value = options.getProperty(runtime, "audioBitRate");
+          if (value.isNumber()) {
+            audioBitRate = value.asNumber();
+          }
+        }
+        if (options.hasProperty(runtime, "audioSampleRate")) {
+          auto value = options.getProperty(runtime, "audioSampleRate");
+          if (value.isNumber()) {
+            audioSampleRate = value.asNumber();
+          }
+        }
+        if (options.hasProperty(runtime, "audioChannelCount")) {
+          auto value = options.getProperty(runtime, "audioChannelCount");
+          if (value.isNumber()) {
+            audioChannelCount = value.asNumber();
+          }
+        }
+
+        std::shared_ptr<VideoComposition> composition = nullptr;
+        if (count >= 2 && arguments[1].isObject()) {
+          auto jsComposition = arguments[1].asObject(runtime);
+          composition = VideoComposition::fromJS(runtime, jsComposition);
+        }
 
         auto instance = std::make_shared<VideoEncoderHostObject>(
-            outPath, width, height, frameRate, bitRate);
+            outPath, width, height, frameRate, bitRate, audioBitRate,
+            audioSampleRate, audioChannelCount, composition);
         return jsi::Object::createFromHostObject(runtime, instance);
       });
   RNSVModule.setProperty(runtime, "createVideoEncoder",

--- a/ios/ReactNativeSkiaVideo.mm
+++ b/ios/ReactNativeSkiaVideo.mm
@@ -137,8 +137,10 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
       [](jsi::Runtime& runtime, const jsi::Value& thisValue,
          const jsi::Value* arguments, size_t count) -> jsi::Value {
         if (count < 1 || !arguments[0].isObject()) {
-          throw jsi::JSError(runtime, "ReactNativeSkiaVideo.createVideoEncoder("
-                                      "..) expects one arguments (object)!");
+          throw jsi::JSError(
+              runtime,
+              "ReactNativeSkiaVideo.createVideoEncoder(..) expects an options "
+              "object and an optional composition object!");
         }
 
         auto options = arguments[0].asObject(runtime);

--- a/ios/VideoComposition.h
+++ b/ios/VideoComposition.h
@@ -13,12 +13,24 @@ public:
   double startTime;
   double duration;
   CGSize resolution;
+  bool isVideo = true;
+  bool audioEnabled = false;
+  double audioVolume = 1.0;
 };
 
 class VideoComposition {
 public:
   double duration;
   std::vector<std::shared_ptr<VideoCompositionItem>> items;
+
+  bool hasAudio() const {
+    for (const auto& item : items) {
+      if (item->audioEnabled) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   static std::shared_ptr<VideoComposition> fromJS(jsi::Runtime& runtime,
                                                   jsi::Object& jsComposition) {
@@ -48,6 +60,36 @@ public:
           item->resolution.width = res.getProperty(runtime, "width").asNumber();
           item->resolution.height =
               res.getProperty(runtime, "height").asNumber();
+        }
+      }
+
+      if (jsItem.hasProperty(runtime, "kind")) {
+        auto kindProp = jsItem.getProperty(runtime, "kind");
+        if (kindProp.isString()) {
+          item->isVideo = kindProp.asString(runtime).utf8(runtime) != "audio";
+        }
+      }
+      if (!item->isVideo) {
+        item->audioEnabled = true;
+        if (jsItem.hasProperty(runtime, "volume")) {
+          auto volumeProp = jsItem.getProperty(runtime, "volume");
+          if (volumeProp.isNumber()) {
+            item->audioVolume = volumeProp.asNumber();
+          }
+        }
+      } else if (jsItem.hasProperty(runtime, "audio")) {
+        auto audioProp = jsItem.getProperty(runtime, "audio");
+        if (audioProp.isBool()) {
+          item->audioEnabled = audioProp.getBool();
+        } else if (audioProp.isObject()) {
+          item->audioEnabled = true;
+          auto audio = audioProp.asObject(runtime);
+          if (audio.hasProperty(runtime, "volume")) {
+            auto volumeProp = audio.getProperty(runtime, "volume");
+            if (volumeProp.isNumber()) {
+              item->audioVolume = volumeProp.asNumber();
+            }
+          }
         }
       }
 

--- a/ios/VideoCompositionFramesExtractorHostObject.h
+++ b/ios/VideoCompositionFramesExtractorHostObject.h
@@ -50,6 +50,10 @@ private:
   bool isPlaying = false;
   bool isLooping = false;
   bool initialized = false;
+  bool completeEmitted = false;
+  // Plays the audio of the composition; when present it is also the master
+  // clock of the playback.
+  AVPlayer* audioPlayer;
   std::atomic_flag released = ATOMIC_FLAG_INIT;
 
   void prepare();

--- a/ios/VideoCompositionFramesExtractorHostObject.mm
+++ b/ios/VideoCompositionFramesExtractorHostObject.mm
@@ -1,6 +1,7 @@
 #include "VideoCompositionFramesExtractorHostObject.h"
 
 #import "AVAssetTrackUtils.h"
+#import "AudioCompositionUtils.h"
 #import "JSIUtils.h"
 #import <AVFoundation/AVFoundation.h>
 #import <Foundation/Foundation.h>
@@ -191,14 +192,29 @@ void VideoCompositionFramesExtractorHostObject::prepare() {
             }
             auto currentTime = getCurrentTime();
             if (CMTimeGetSeconds(currentTime) >= composition->duration) {
-              emit("complete", jsi::Value::null());
+              if (!completeEmitted) {
+                completeEmitted = true;
+                emit("complete", jsi::Value::null());
+              }
               if (isLooping) {
                 currentTime = kCMTimeZero;
                 startDate = [NSDate date];
+                if (audioPlayer) {
+                  [audioPlayer seekToTime:kCMTimeZero
+                          toleranceBefore:kCMTimeZero
+                           toleranceAfter:kCMTimeZero
+                        completionHandler:^(BOOL){
+                        }];
+                }
               } else {
                 isPlaying = false;
+                if (audioPlayer) {
+                  [audioPlayer pause];
+                }
                 return;
               }
+            } else {
+              completeEmitted = false;
             }
             for (const auto& entry : itemDecoders) {
               auto decoder = entry.second;
@@ -223,12 +239,38 @@ void VideoCompositionFramesExtractorHostObject::init() {
       return;
     }
     try {
+      // Assets are shared between the video decoders and the audio
+      // composition so a same file is never opened twice.
+      NSMutableDictionary<NSString*, AVURLAsset*>* assetCache =
+          [NSMutableDictionary dictionary];
       for (const auto& item : composition->items) {
-        itemDecoders[item->id] =
-            std::make_shared<VideoCompositionItemDecoder>(item, true);
+        if (!item->isVideo) {
+          continue;
+        }
+        itemDecoders[item->id] = std::make_shared<VideoCompositionItemDecoder>(
+            item, true, getOrCreateAsset(item->path, assetCache));
+      }
+      if (composition->hasAudio()) {
+        auto audioComposition = buildAudioComposition(composition, assetCache);
+        if (audioComposition.composition) {
+          AVPlayerItem* playerItem =
+              [AVPlayerItem playerItemWithAsset:audioComposition.composition];
+          if (audioComposition.audioMix) {
+            playerItem.audioMix = audioComposition.audioMix;
+          }
+          audioPlayer = [AVPlayer playerWithPlayerItem:playerItem];
+          audioPlayer.actionAtItemEnd = AVPlayerActionAtItemEndNone;
+          audioPlayer.automaticallyWaitsToMinimizeStalling = NO;
+          if (CMTimeCompare(pausePosition, kCMTimeZero) > 0) {
+            [audioPlayer seekToTime:pausePosition
+                    toleranceBefore:kCMTimeZero
+                     toleranceAfter:kCMTimeZero];
+          }
+        }
       }
     } catch (NSError* error) {
       itemDecoders.clear();
+      audioPlayer = nil;
       emit("error", [=](jsi::Runtime& runtime) -> jsi::Value {
         return RNSkiaVideo::NSErrorToJSI(runtime, error);
       });
@@ -243,6 +285,14 @@ void VideoCompositionFramesExtractorHostObject::init() {
 }
 
 void VideoCompositionFramesExtractorHostObject::play() {
+  if (audioPlayer) {
+    if (CMTimeGetSeconds(audioPlayer.currentTime) >= composition->duration) {
+      [audioPlayer seekToTime:kCMTimeZero
+              toleranceBefore:kCMTimeZero
+               toleranceAfter:kCMTimeZero];
+    }
+    [audioPlayer play];
+  }
   startDate =
       [NSDate dateWithTimeIntervalSinceNow:-CMTimeGetSeconds(pausePosition)];
   pausePosition = kCMTimeZero;
@@ -255,6 +305,9 @@ void VideoCompositionFramesExtractorHostObject::pause() {
   }
   pausePosition = getCurrentTime();
   isPlaying = false;
+  if (audioPlayer) {
+    [audioPlayer pause];
+  }
 }
 
 void VideoCompositionFramesExtractorHostObject::seekTo(CMTime time) {
@@ -262,6 +315,11 @@ void VideoCompositionFramesExtractorHostObject::seekTo(CMTime time) {
     startDate = [NSDate dateWithTimeIntervalSinceNow:-CMTimeGetSeconds(time)];
   } else {
     pausePosition = time;
+  }
+  if (audioPlayer) {
+    [audioPlayer seekToTime:time
+            toleranceBefore:kCMTimeZero
+             toleranceAfter:kCMTimeZero];
   }
   @synchronized(lock) {
     for (const auto& entry : itemDecoders) {
@@ -272,6 +330,13 @@ void VideoCompositionFramesExtractorHostObject::seekTo(CMTime time) {
 
 CMTime VideoCompositionFramesExtractorHostObject::getCurrentTime() {
   if (isPlaying) {
+    // When the composition has audio, the audio player is the master clock.
+    if (audioPlayer) {
+      CMTime time = audioPlayer.currentTime;
+      if (CMTIME_IS_NUMERIC(time)) {
+        return time;
+      }
+    }
     NSTimeInterval elapsedTime =
         [[NSDate date] timeIntervalSinceDate:startDate];
     return CMTimeMakeWithSeconds(elapsedTime, NSEC_PER_SEC);
@@ -296,6 +361,11 @@ void VideoCompositionFramesExtractorHostObject::release() {
     }
     itemDecoders.clear();
     currentFrames.clear();
+    if (audioPlayer) {
+      [audioPlayer pause];
+      [audioPlayer replaceCurrentItemWithPlayerItem:nil];
+      audioPlayer = nil;
+    }
   }
   removeAllListeners();
   if (displayLink != nullptr) {

--- a/ios/VideoCompositionFramesExtractorSyncHostObject.mm
+++ b/ios/VideoCompositionFramesExtractorSyncHostObject.mm
@@ -39,6 +39,9 @@ jsi::Value VideoCompositionFramesExtractorSyncHostObject::get(
                const jsi::Value* arguments, size_t count) -> jsi::Value {
           try {
             for (const auto& item : composition->items) {
+              if (!item->isVideo) {
+                continue;
+              }
               itemDecoders[item->id] =
                   std::make_shared<VideoCompositionItemDecoder>(item, false);
             }

--- a/ios/VideoCompositionItemDecoder.h
+++ b/ios/VideoCompositionItemDecoder.h
@@ -12,7 +12,7 @@ namespace RNSkiaVideo {
 class VideoCompositionItemDecoder {
 public:
   VideoCompositionItemDecoder(std::shared_ptr<VideoCompositionItem> item,
-                              bool realTime);
+                              bool realTime, AVURLAsset* sharedAsset = nil);
   ~VideoCompositionItemDecoder();
   void advanceDecoder(CMTime currentTime);
   void seekTo(CMTime currentTime);

--- a/ios/VideoCompositionItemDecoder.mm
+++ b/ios/VideoCompositionItemDecoder.mm
@@ -8,14 +8,17 @@
 namespace RNSkiaVideo {
 
 VideoCompositionItemDecoder::VideoCompositionItemDecoder(
-    std::shared_ptr<VideoCompositionItem> item, bool realTime) {
+    std::shared_ptr<VideoCompositionItem> item, bool realTime,
+    AVURLAsset* sharedAsset) {
   this->item = item;
   this->realTime = realTime;
   lock = [[NSObject alloc] init];
   NSString* path =
       [NSString stringWithCString:item->path.c_str()
                          encoding:[NSString defaultCStringEncoding]];
-  asset = [AVURLAsset URLAssetWithURL:[NSURL fileURLWithPath:path] options:nil];
+  asset = sharedAsset
+              ?: [AVURLAsset URLAssetWithURL:[NSURL fileURLWithPath:path]
+                                     options:nil];
   videoTrack = [[asset tracksWithMediaType:AVMediaTypeVideo] firstObject];
   if (!videoTrack) {
     throw [NSError

--- a/ios/VideoEncoderHostObject.h
+++ b/ios/VideoEncoderHostObject.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#import "VideoComposition.h"
 #import <AVFoundation/AVFoundation.h>
 #import <jsi/jsi.h>
 #import <map>
@@ -10,7 +11,9 @@ using namespace facebook;
 class JSI_EXPORT VideoEncoderHostObject : public jsi::HostObject {
 public:
   VideoEncoderHostObject(std::string outPath, int width, int height,
-                         int frameRate, int bitRate);
+                         int frameRate, int bitRate, int audioBitRate,
+                         int audioSampleRate, int audioChannelCount,
+                         std::shared_ptr<VideoComposition> composition);
   jsi::Value get(jsi::Runtime&, const jsi::PropNameID& name) override;
   std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& rt) override;
 
@@ -20,6 +23,10 @@ private:
   int height;
   int bitRate;
   int frameRate;
+  int audioBitRate;
+  int audioSampleRate;
+  int audioChannelCount;
+  std::shared_ptr<VideoComposition> composition;
   id<MTLDevice> device;
   id<MTLCommandQueue> commandQueue;
   id<MTLTexture> cpuAccessibleTexture;
@@ -27,8 +34,17 @@ private:
   AVAssetWriterInput* assetWriterInput;
   CVPixelBufferPoolRef pixelBufferPool = NULL;
 
+  AVAssetWriterInput* audioWriterInput;
+  AVAssetReader* audioReader;
+  AVAssetReaderAudioMixOutput* audioMixOutput;
+  dispatch_queue_t audioQueue;
+  dispatch_semaphore_t audioCompletionSemaphore;
+  NSMutableArray<NSError*>* audioErrorHolder;
+
   void prepare();
   void encodeFrame(id<MTLTexture> mlTexture, CMTime time);
+  void setupAudio();
+  void startWritingAudio();
   void finish();
   void release();
 };

--- a/ios/VideoEncoderHostObject.mm
+++ b/ios/VideoEncoderHostObject.mm
@@ -1,4 +1,5 @@
 #import "VideoEncoderHostObject.h"
+#import "AudioCompositionUtils.h"
 #import "JsiUtils.h"
 #import <Metal/Metal.h>
 #import <future>
@@ -11,14 +12,19 @@ NS_INLINE NSError* createErrorWithMessage(NSString* message) {
 
 namespace RNSkiaVideo {
 
-VideoEncoderHostObject::VideoEncoderHostObject(std::string outPath, int width,
-                                               int height, int frameRate,
-                                               int bitRate) {
+VideoEncoderHostObject::VideoEncoderHostObject(
+    std::string outPath, int width, int height, int frameRate, int bitRate,
+    int audioBitRate, int audioSampleRate, int audioChannelCount,
+    std::shared_ptr<VideoComposition> composition) {
   this->outPath = outPath;
   this->width = width;
   this->height = height;
   this->frameRate = frameRate;
   this->bitRate = bitRate;
+  this->audioBitRate = audioBitRate;
+  this->audioSampleRate = audioSampleRate;
+  this->audioChannelCount = audioChannelCount;
+  this->composition = composition;
 }
 
 std::vector<jsi::PropNameID>
@@ -117,8 +123,17 @@ void VideoEncoderHostObject::prepare() {
         ?: createErrorWithMessage(@"could not add output to asset writter");
     return;
   }
+
+  if (composition && composition->hasAudio()) {
+    setupAudio();
+  }
+
   [assetWriter startWriting];
   [assetWriter startSessionAtSourceTime:kCMTimeZero];
+
+  if (audioWriterInput) {
+    startWritingAudio();
+  }
 
   device = MTLCreateSystemDefaultDevice();
   commandQueue = [device newCommandQueue];
@@ -248,7 +263,140 @@ void VideoEncoderHostObject::encodeFrame(id<MTLTexture> mlTexture,
   }
 }
 
+void VideoEncoderHostObject::setupAudio() {
+  auto audioComposition = buildAudioComposition(composition, nil);
+  if (!audioComposition.composition) {
+    return;
+  }
+
+  NSError* error = nil;
+  audioReader = [AVAssetReader assetReaderWithAsset:audioComposition.composition
+                                              error:&error];
+  if (error) {
+    throw error;
+  }
+  // The audio composition is padded with silence past the composition
+  // duration, clamp the export to the exact video duration.
+  audioReader.timeRange = CMTimeRangeMake(
+      kCMTimeZero, CMTimeMakeWithSeconds(composition->duration, NSEC_PER_SEC));
+
+  NSDictionary* pcmSettings = @{
+    AVFormatIDKey : @(kAudioFormatLinearPCM),
+    AVSampleRateKey : @(audioSampleRate),
+    AVNumberOfChannelsKey : @(audioChannelCount),
+    AVLinearPCMBitDepthKey : @(16),
+    AVLinearPCMIsFloatKey : @(NO),
+    AVLinearPCMIsBigEndianKey : @(NO),
+    AVLinearPCMIsNonInterleaved : @(NO)
+  };
+  audioMixOutput = [[AVAssetReaderAudioMixOutput alloc]
+      initWithAudioTracks:[audioComposition.composition
+                              tracksWithMediaType:AVMediaTypeAudio]
+            audioSettings:pcmSettings];
+  if (audioComposition.audioMix) {
+    audioMixOutput.audioMix = audioComposition.audioMix;
+  }
+  if (![audioReader canAddOutput:audioMixOutput]) {
+    throw createErrorWithMessage(@"Could not read composition audio");
+  }
+  [audioReader addOutput:audioMixOutput];
+
+  NSDictionary* aacSettings = @{
+    AVFormatIDKey : @(kAudioFormatMPEG4AAC),
+    AVSampleRateKey : @(audioSampleRate),
+    AVNumberOfChannelsKey : @(audioChannelCount),
+    AVEncoderBitRateKey : @(audioBitRate)
+  };
+  audioWriterInput =
+      [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeAudio
+                                         outputSettings:aacSettings];
+  audioWriterInput.expectsMediaDataInRealTime = NO;
+  if ([assetWriter canAddInput:audioWriterInput]) {
+    [assetWriter addInput:audioWriterInput];
+  } else {
+    audioWriterInput = nil;
+    throw assetWriter.error
+        ?: createErrorWithMessage(
+               @"could not add audio output to asset writter");
+  }
+}
+
+void VideoEncoderHostObject::startWritingAudio() {
+  if (![audioReader startReading]) {
+    throw audioReader.error
+        ?: createErrorWithMessage(@"Could not read composition audio");
+  }
+  audioCompletionSemaphore = dispatch_semaphore_create(0);
+  audioErrorHolder = [NSMutableArray array];
+  dispatch_queue_attr_t attr = dispatch_queue_attr_make_with_qos_class(
+      DISPATCH_QUEUE_SERIAL, QOS_CLASS_UTILITY, 0);
+  audioQueue = dispatch_queue_create("RNSkiaVideoAudioEncoder", attr);
+
+  // The block only captures ObjC objects, never `this`, so it can safely
+  // outlive this host object.
+  AVAssetWriterInput* input = audioWriterInput;
+  AVAssetReaderAudioMixOutput* output = audioMixOutput;
+  AVAssetReader* reader = audioReader;
+  AVAssetWriter* writer = assetWriter;
+  dispatch_semaphore_t semaphore = audioCompletionSemaphore;
+  NSMutableArray<NSError*>* errorHolder = audioErrorHolder;
+  __block BOOL finished = NO;
+  [input
+      requestMediaDataWhenReadyOnQueue:audioQueue
+                            usingBlock:^{
+                              if (finished) {
+                                return;
+                              }
+                              while (input.isReadyForMoreMediaData) {
+                                CMSampleBufferRef sampleBuffer =
+                                    [output copyNextSampleBuffer];
+                                if (!sampleBuffer) {
+                                  if (reader.status ==
+                                      AVAssetReaderStatusFailed) {
+                                    [errorHolder
+                                        addObject:reader.error
+                                                      ?: createErrorWithMessage(
+                                                             @"Could not read "
+                                                             @"composition "
+                                                             @"audio")];
+                                  }
+                                  finished = YES;
+                                  [input markAsFinished];
+                                  dispatch_semaphore_signal(semaphore);
+                                  return;
+                                }
+                                BOOL appended =
+                                    [input appendSampleBuffer:sampleBuffer];
+                                CFRelease(sampleBuffer);
+                                if (!appended) {
+                                  [errorHolder
+                                      addObject:writer.error
+                                                    ?: createErrorWithMessage(
+                                                           @"Could not append "
+                                                           @"audio data to "
+                                                           @"AVAssetWriter")];
+                                  [reader cancelReading];
+                                  finished = YES;
+                                  [input markAsFinished];
+                                  dispatch_semaphore_signal(semaphore);
+                                  return;
+                                }
+                              }
+                            }];
+}
+
 void VideoEncoderHostObject::finish() {
+  // The video input must be marked as finished BEFORE waiting for the
+  // audio: AVAssetWriter interleaves the two tracks and would keep the
+  // audio input not-ready while waiting for more video data (deadlock).
+  [assetWriterInput markAsFinished];
+  if (audioWriterInput) {
+    dispatch_semaphore_wait(audioCompletionSemaphore, DISPATCH_TIME_FOREVER);
+    NSError* audioError = audioErrorHolder.firstObject;
+    if (audioError) {
+      throw audioError;
+    }
+  }
 
   __block std::promise<void> promise;
   std::future<void> future = promise.get_future();
@@ -256,7 +404,6 @@ void VideoEncoderHostObject::finish() {
   [assetWriter finishWritingWithCompletionHandler:^{
     if (assetWriter.status == AVAssetWriterStatusFailed) {
       error = assetWriter.error ?: createErrorWithMessage(@"Failed to export");
-      return;
     }
     promise.set_value();
   }];
@@ -268,6 +415,18 @@ void VideoEncoderHostObject::finish() {
 }
 
 void VideoEncoderHostObject::release() {
+  if (audioReader && audioReader.status == AVAssetReaderStatusReading) {
+    [audioReader cancelReading];
+  }
+  if (audioQueue) {
+    // Wait for any in-flight audio block before tearing down the writer.
+    dispatch_sync(audioQueue, ^{
+                  });
+    audioQueue = nil;
+  }
+  audioReader = nil;
+  audioMixOutput = nil;
+  audioWriterInput = nil;
   if (assetWriter && assetWriter.status == AVAssetWriterStatusWriting) {
     [assetWriter cancelWriting];
   }

--- a/ios/VideoEncoderHostObject.mm
+++ b/ios/VideoEncoderHostObject.mm
@@ -120,7 +120,7 @@ void VideoEncoderHostObject::prepare() {
     [assetWriter addInput:assetWriterInput];
   } else {
     throw assetWriter.error
-        ?: createErrorWithMessage(@"could not add output to asset writter");
+        ?: createErrorWithMessage(@"could not add output to asset writer");
     return;
   }
 
@@ -317,7 +317,7 @@ void VideoEncoderHostObject::setupAudio() {
     audioWriterInput = nil;
     throw assetWriter.error
         ?: createErrorWithMessage(
-               @"could not add audio output to asset writter");
+               @"could not add audio output to asset writer");
   }
 }
 

--- a/src/exportVideoComposition.ts
+++ b/src/exportVideoComposition.ts
@@ -13,6 +13,10 @@ import { runOnNewThread } from './utils/thread';
 
 const Promise = global.Promise;
 
+const DEFAULT_AUDIO_BIT_RATE = 128000;
+const DEFAULT_AUDIO_SAMPLE_RATE = 44100;
+const DEFAULT_AUDIO_CHANNEL_COUNT = 2;
+
 /**
  * Exports a video composition to a video file.
  *
@@ -70,7 +74,17 @@ export const exportVideoComposition = async <T = undefined>({
           throw new Error('Failed to create Skia surface');
         }
 
-        encoder = RNSkiaVideoModule.createVideoEncoder(options);
+        encoder = RNSkiaVideoModule.createVideoEncoder(
+          {
+            ...options,
+            audioBitRate: options.audioBitRate ?? DEFAULT_AUDIO_BIT_RATE,
+            audioSampleRate:
+              options.audioSampleRate ?? DEFAULT_AUDIO_SAMPLE_RATE,
+            audioChannelCount:
+              options.audioChannelCount ?? DEFAULT_AUDIO_CHANNEL_COUNT,
+          },
+          videoComposition
+        );
         encoder.prepare();
 
         frameExtractor =

--- a/src/types.ts
+++ b/src/types.ts
@@ -160,13 +160,13 @@ export type VideoComposition = {
   duration: number;
 };
 
-export type VideoCompositionItem = {
+type VideoCompositionItemBase = {
   /**
    * The unique identifier of the item.
    */
   id: string;
   /**
-   * The path to the video file.
+   * The path to the media file.
    * only support local file path
    */
   path: string;
@@ -175,20 +175,54 @@ export type VideoCompositionItem = {
    */
   compositionStartTime: number;
   /**
-   * The start time in seconds of the item within the video.
+   * The start time in seconds of the item within the media.
    */
   startTime: number;
   /**
    * The duration in seconds of the item.
    */
   duration: number;
+};
+
+/**
+ * A video item of a composition. Produces frames passed to the `drawFrame`
+ * function. Video items are silent by default; set `audio` to also play
+ * the audio track of the video file.
+ */
+export type VideoCompositionVideoItem = VideoCompositionItemBase & {
+  kind?: 'video';
   /**
    * If provided, the resolution to scale the video to.
    * If not provided, the original resolution of the video will be used.
    * Downscaling the video can improve performance.
    */
   resolution?: { width: number; height: number };
+  /**
+   * If set, the audio track of the video file will be played (during
+   * playback) and mixed into the exported video (during export), following
+   * the same time mapping as the video frames.
+   * Defaults to false (video items are silent).
+   */
+  audio?: boolean | { volume?: number };
 };
+
+/**
+ * An audio item of a composition. Does not produce frames; its audio track
+ * is played during playback and mixed into the exported video during export.
+ * The source file can be an audio file or a video file (in which case its
+ * audio track is used).
+ */
+export type VideoCompositionAudioItem = VideoCompositionItemBase & {
+  kind: 'audio';
+  /**
+   * The volume of the item, between 0 and 1.
+   * Defaults to 1.
+   */
+  volume?: number;
+};
+
+export type VideoCompositionItem =
+  VideoCompositionVideoItem | VideoCompositionAudioItem;
 
 /**
  * Function that draws a video composition frame to a canvas.
@@ -213,6 +247,7 @@ export type FrameDrawer<T = undefined> = (args: {
   currentTime: number;
   /**
    * The decoded video frames of the composition items.
+   * Only video items produce frames; audio items never appear in this map.
    */
   frames: Record<string, VideoFrame>;
   /**
@@ -355,6 +390,24 @@ export type ExportOptions = {
    * @platform android
    */
   encoderName?: string | null;
+  /**
+   * The bit rate of the exported audio track in bits per second.
+   * Only used if the composition contains audio.
+   * @default 128000
+   */
+  audioBitRate?: number;
+  /**
+   * The sample rate of the exported audio track in Hz.
+   * Only used if the composition contains audio.
+   * @default 44100
+   */
+  audioSampleRate?: number;
+  /**
+   * The number of channels of the exported audio track (1 = mono, 2 = stereo).
+   * Only used if the composition contains audio.
+   * @default 2
+   */
+  audioChannelCount?: number;
 };
 
 export type RNSkiaVideoModule = {
@@ -397,13 +450,19 @@ export type RNSkiaVideoModule = {
   /**
    * Creates a video composition encoder for the specified export options.
    * @param options The export options for the video composition.
+   * @param composition The video composition being exported; used to encode
+   * the audio tracks of the composition items (if any).
    * @returns The video composition encoder.
    */
   createVideoEncoder: (
     /**
      * The export options for the video composition.
      */
-    options: ExportOptions
+    options: ExportOptions,
+    /**
+     * The video composition being exported (used for audio encoding).
+     */
+    composition?: VideoComposition | null
   ) => VideoEncoder;
   /**
    * Returns the decoding capabilities of the current platform for the specified mimetype.

--- a/src/videoCompositionPlayer.ts
+++ b/src/videoCompositionPlayer.ts
@@ -132,7 +132,13 @@ export const useVideoCompositionPlayer = ({
 
   const errorHandler = useCallback(
     (error: any) => {
-      onError?.(error, retry);
+      if (onError) {
+        onError(error, retry);
+      } else {
+        // Without handler the player would silently turn into a black
+        // screen, at least log the error.
+        console.error('useVideoCompositionPlayer error:', error);
+      }
       setIsErrored(true);
     },
     [onError, retry]

--- a/src/videoCompositionPlayer.ts
+++ b/src/videoCompositionPlayer.ts
@@ -132,13 +132,7 @@ export const useVideoCompositionPlayer = ({
 
   const errorHandler = useCallback(
     (error: any) => {
-      if (onError) {
-        onError(error, retry);
-      } else {
-        // Without handler the player would silently turn into a black
-        // screen, at least log the error.
-        console.error('useVideoCompositionPlayer error:', error);
-      }
+      onError?.(error, retry);
       setIsErrored(true);
     },
     [onError, retry]


### PR DESCRIPTION
## Summary

Adds declarative audio support to the video composition system, applied consistently **during playback and export**:

```ts
const videoComposition = {
  duration: 10,
  items: [
    {
      id: 'video1',
      path: 'path/to/video.mp4',
      compositionStartTime: 0,
      startTime: 0,
      duration: 10,
      // plays the audio track of the video, in sync with its frames
      audio: { volume: 0.8 }, // or simply `audio: true`
    },
    {
      // standalone audio (music, voice over...); the source can be an
      // audio file or the audio track of any video file
      id: 'music',
      kind: 'audio',
      path: 'path/to/music.mp3',
      compositionStartTime: 0,
      startTime: 12,
      duration: 10,
      volume: 0.3,
    },
  ],
};
```

- Video items stay **silent by default** (backward compatible); `audio` opts into their audio track with the same time mapping as the frames.
- `kind: 'audio'` items never produce frames (they don't appear in the `frames` map of `drawFrame`) and never instantiate a video decoder.
- Overlapping audio is mixed together, with per-item volume.
- New export options: `audioBitRate` (128kbps), `audioSampleRate` (44100Hz), `audioChannelCount` (2) — the exported file gets an AAC audio track.

## Implementation

**iOS** — the audio timeline is built once as an audio-only `AVMutableComposition` + `AVMutableAudioMix` (`AudioCompositionUtils`), shared by both paths:
- *Playback*: played by a single `AVPlayer` which also becomes the **master clock** of the composition, guaranteeing A/V sync by construction.
- *Export*: read (already mixed) by an `AVAssetReaderAudioMixOutput` and written to a second `AVAssetWriterInput` on a background queue, in parallel of the video frames pushed from JS. The video input is marked as finished before waiting for the audio drain (AVAssetWriter interleaving would otherwise deadlock).
- `AVURLAsset`s are cached by path: an item referenced both for its frames and its audio never instantiates its resources twice.

**Android**:
- *Playback*: one audio-only ExoPlayer per audio-enabled item (video track selection disabled), slaved to the composition clock. Small drifts are caught up by adjusting the playback speed (pitch preserving, inaudible); hard seeks are reserved to large ruptures; the audio pipeline startup latency is learned and compensated so playback starts in sync without hesitation.
- *Export*: items are decoded (`MediaExtractor`/`MediaCodec`), resampled/channel-converted, mixed on the composition timeline and encoded to AAC on a dedicated thread while JS pushes the video frames; the muxer starts once both tracks are registered (samples produced in the meantime are queued).

The example app demoes both: video items with `audio: true` and a background music item (public domain recording) toggleable with a switch.

## Notes

- This PR **replaces #34**: unlike the per-frame `mixAudio` callback approach, the declarative model covers playback (not only export), supports standalone audio files, keeps the JS thread out of the audio path, and produces sample-accurate output on both platforms.
- v1 scope: no time-stretch (audio plays at speed 1 regardless of slow-motion video mappings), no volume automation/fades yet (the declarative model can accommodate them later).

Resolves #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)