### PR TITLE
fix: exclude docs from the root typecheck

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,5 +28,6 @@
     "target": "esnext",
     "types": ["node", "jest"],
     "verbatimModuleSyntax": true
-  }
+  },
+  "exclude": ["node_modules", "lib", "docs"]
 }


### PR DESCRIPTION
The documentation site has its own package.json and toolchain; its dependencies are not installed by the root CI job, so tsc failed resolving Docusaurus modules. The site is already type-checked by its own build.


Claude-Session: https://claude.ai/code/session_01QzAxcecueWNX3QBPXKU27v