### PR TITLE
fix: exclude docs from the definition files build

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig",
-  "exclude": ["example"]
+  "exclude": ["example", "docs", "node_modules", "lib"]
 }


### PR DESCRIPTION
tsconfig.build.json's own exclude replaces (not merges with) the root tsconfig's, so bob's typescript target was still compiling the Docusaurus site whose dependencies are not installed at the repo root.


Claude-Session: https://claude.ai/code/session_01QzAxcecueWNX3QBPXKU27v