### PR TITLE
fix(ios): let the texture cache release the surfaces it pins

### DIFF
--- a/ios/MTLTextureUtils.h
+++ b/ios/MTLTextureUtils.h
@@ -14,14 +14,29 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MTLTextureUtils : NSObject
 
 /**
+ * The device backing the texture cache below. Everything that blits to or
+ * from a texture obtained from this class must use this device, since Metal
+ * cannot mix resources across devices.
+ */
++ (nullable id<MTLDevice>)device;
+
+/**
  * Wraps a BGRA CVPixelBuffer into a Metal texture without copying: the
  * returned CVMetalTexture is a zero-copy view over the buffer's IOSurface.
  * The caller must keep the returned reference (and the pixel buffer) alive
- * for as long as the texture is in use, then CFRelease it.
+ * for as long as the texture is in use, then CFRelease it, and call
+ * `flushTextureCache` once done with the frame.
  */
 + (nullable CVMetalTextureRef)createTextureViewForPixelBuffer:
     (CVPixelBufferRef)pixelBuffer;
 
+/**
+ * Releases the cache's own references to the textures nobody holds anymore.
+ * CoreVideo requires this to be called periodically: until it runs, the
+ * cache keeps every IOSurface it has vended a texture for alive, which stops
+ * the pixel buffer pools those surfaces belong to from ever recycling them.
+ * Textures still retained by a caller are left untouched.
+ */
 + (void)flushTextureCache;
 @end
 

--- a/ios/MTLTextureUtils.mm
+++ b/ios/MTLTextureUtils.mm
@@ -10,19 +10,26 @@
 
 @implementation MTLTextureUtils
 
-static id<MTLDevice> device;
-inline id<MTLDevice> getDevice() {
-  if (!device) {
++ (nullable id<MTLDevice>)device {
+  static id<MTLDevice> device = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
     device = MTLCreateSystemDefaultDevice();
-  }
+  });
   return device;
 }
 
+// The cache is reached from the decoder queues, the render thread and the
+// export thread, sometimes concurrently, and CVMetalTextureCache makes no
+// thread-safety promise, so every access to it goes through this class and is
+// serialized on it.
 static CVMetalTextureCacheRef metalTextureCache = NULL;
-CVMetalTextureCacheRef getMetalTextureCache() {
+
+// Callers must hold the class lock.
++ (nullable CVMetalTextureCacheRef)cacheLocked {
   if (!metalTextureCache) {
     CVReturn status = CVMetalTextureCacheCreate(
-        kCFAllocatorDefault, NULL, getDevice(), NULL, &metalTextureCache);
+        kCFAllocatorDefault, NULL, [self device], NULL, &metalTextureCache);
     if (status != kCVReturnSuccess) {
       NSLog(@"Failed to create CVMetalTextureCache: %d", status);
       metalTextureCache = NULL;
@@ -33,26 +40,31 @@ CVMetalTextureCacheRef getMetalTextureCache() {
 
 + (nullable CVMetalTextureRef)createTextureViewForPixelBuffer:
     (CVPixelBufferRef)pixelBuffer {
-  CVMetalTextureCacheRef cache = getMetalTextureCache();
-  if (!cache) {
-    return NULL;
-  }
   size_t width = CVPixelBufferGetWidth(pixelBuffer);
   size_t height = CVPixelBufferGetHeight(pixelBuffer);
 
   CVMetalTextureRef cvMetalTexture = NULL;
-  CVReturn status = CVMetalTextureCacheCreateTextureFromImage(
-      kCFAllocatorDefault, cache, pixelBuffer, NULL, MTLPixelFormatBGRA8Unorm,
-      width, height, 0, &cvMetalTexture);
-  if (status != kCVReturnSuccess || !cvMetalTexture) {
-    return NULL;
+  @synchronized(self) {
+    CVMetalTextureCacheRef cache = [self cacheLocked];
+    if (!cache) {
+      return NULL;
+    }
+    CVReturn status = CVMetalTextureCacheCreateTextureFromImage(
+        kCFAllocatorDefault, cache, pixelBuffer, NULL, MTLPixelFormatBGRA8Unorm,
+        width, height, 0, &cvMetalTexture);
+    if (status != kCVReturnSuccess && cvMetalTexture) {
+      CFRelease(cvMetalTexture);
+      cvMetalTexture = NULL;
+    }
   }
   return cvMetalTexture;
 }
 
 + (void)flushTextureCache {
-  if (metalTextureCache) {
-    CVMetalTextureCacheFlush(metalTextureCache, 0);
+  @synchronized(self) {
+    if (metalTextureCache) {
+      CVMetalTextureCacheFlush(metalTextureCache, 0);
+    }
   }
 }
 

--- a/ios/RNSVVideoPlayer.mm
+++ b/ios/RNSVVideoPlayer.mm
@@ -34,8 +34,11 @@ static void* rateContext = &rateContext;
 
   AVAsset* asset = [AVAsset assetWithURL:url];
   self.resolution = resolution;
+  // IOSurface-backed: the frames are wrapped into Metal texture views without
+  // a copy, and their recycling is gated on the surface's use count.
   NSDictionary* pixBuffAttributes = @{
     (id)kCVPixelBufferPixelFormatTypeKey : @(kCVPixelFormatType_32BGRA),
+    (id)kCVPixelBufferIOSurfacePropertiesKey : @{},
     (id)kCVPixelBufferMetalCompatibilityKey : @YES
   };
   if (!CGSizeEqualToSize(CGSizeZero, resolution)) {

--- a/ios/VideoCompositionItemDecoder.h
+++ b/ios/VideoCompositionItemDecoder.h
@@ -35,10 +35,9 @@ private:
   std::list<std::pair<double, CMSampleBufferRef>> nextLoopFrames;
   CMTime lastRequestedTime = kCMTimeInvalid;
   std::shared_ptr<VideoFrame> currentFrame;
-  // Recently issued frames and retired frames awaiting surface idleness;
-  // lifetime never depends on the JS garbage collector (see VideoFrame.h).
-  std::list<std::shared_ptr<VideoFrame>> issuedFrames;
-  std::list<std::shared_ptr<VideoFrame>> retiredFrames;
+  // Bounds the lifetime of the frames handed to JS; never depends on the JS
+  // garbage collector (see VideoFrame.h).
+  VideoFrameRing frameRing;
 
   void setupReader(CMTime initialTime);
   double mapSourceTimeToTarget(CMTime sourceTime);

--- a/ios/VideoCompositionItemDecoder.mm
+++ b/ios/VideoCompositionItemDecoder.mm
@@ -1,5 +1,4 @@
 #include "VideoCompositionItemDecoder.h"
-#include "MTLTextureUtils.h"
 
 #import "AVAssetTrackUtils.h"
 #import <AVFoundation/AVFoundation.h>
@@ -223,27 +222,10 @@ VideoCompositionItemDecoder::acquireFrameForTime(CMTime currentTime,
     auto frame = std::make_shared<VideoFrame>(buffer, width, height, rotation);
     CFRelease(nextFrame);
     // Deterministic lifetime (see VideoFrame.h): frames older than the ring
-    // lose their texture immediately, and their buffer returns to the pool
-    // only once the kernel reports their IOSurface idle — never under
-    // pending GPU sampling work. Stale JS wrappers see an undefined texture
-    // instead of pinning a decoder buffer until garbage collection.
-    issuedFrames.push_back(frame);
-    while (issuedFrames.size() > kIssuedFrameRingDepth) {
-      issuedFrames.front()->releaseTexture();
-      retiredFrames.push_back(issuedFrames.front());
-      issuedFrames.pop_front();
-    }
-    for (auto it = retiredFrames.begin(); it != retiredFrames.end();) {
-      if ((*it)->tryReleaseBuffer()) {
-        it = retiredFrames.erase(it);
-      } else {
-        ++it;
-      }
-    }
-    while (retiredFrames.size() > kRetiredFramesHardCap) {
-      retiredFrames.front()->releaseBuffer();
-      retiredFrames.pop_front();
-    }
+    // lose their texture immediately, and their buffer returns to the pool as
+    // soon as nothing reads it anymore. Stale JS wrappers see an undefined
+    // texture instead of pinning a decoder buffer until garbage collection.
+    frameRing.push(frame);
     return frame;
   }
   return nullptr;
@@ -270,19 +252,11 @@ void VideoCompositionItemDecoder::release() {
       CFRelease(frame.second);
     }
     nextLoopFrames.clear();
-    for (const auto& frame : issuedFrames) {
-      frame->releaseBuffer();
-    }
-    issuedFrames.clear();
-    for (const auto& frame : retiredFrames) {
-      frame->releaseBuffer();
-    }
-    retiredFrames.clear();
+    frameRing.releaseAll();
     hasLooped = false;
     lastRequestedTime = kCMTimeInvalid;
     currentFrame = nullptr;
   }
-  [MTLTextureUtils flushTextureCache];
 }
 
 } // namespace RNSkiaVideo

--- a/ios/VideoCompositionItemDecoder.mm
+++ b/ios/VideoCompositionItemDecoder.mm
@@ -8,7 +8,12 @@ namespace RNSkiaVideo {
 
 VideoCompositionItemDecoder::VideoCompositionItemDecoder(
     std::shared_ptr<VideoCompositionItem> item, bool realTime,
-    AVURLAsset* sharedAsset) {
+    AVURLAsset* sharedAsset)
+    // The sync (export) consumer flushes the GPU before asking for the next
+    // frame, so retiring a frame the moment it is replaced is safe and keeps
+    // one decoded buffer alive per item instead of four — at 4K that is
+    // ~100MB less per item during an export.
+    : frameRing(realTime ? kPreviewFrameRingDepth : 1) {
   this->item = item;
   this->realTime = realTime;
   lock = [[NSObject alloc] init];

--- a/ios/VideoEncoderHostObject.mm
+++ b/ios/VideoEncoderHostObject.mm
@@ -132,7 +132,9 @@ void VideoEncoderHostObject::prepare() {
     startWritingAudio();
   }
 
-  device = MTLCreateSystemDefaultDevice();
+  // Same device as the texture cache: the blit below writes into a texture
+  // that cache vends, and Metal cannot mix resources across devices.
+  device = [MTLTextureUtils device];
   commandQueue = [device newCommandQueue];
 
   NSDictionary* attributes = @{
@@ -186,14 +188,21 @@ void VideoEncoderHostObject::encodeFrame(id<MTLTexture> mlTexture,
         @"Could not create Metal view over encoder pixel buffer");
   }
 
+  id<MTLTexture> destination = CVMetalTextureGetTexture(cvMetalTexture);
+  // A source larger than the output would read past the destination and fault
+  // the GPU, so crop instead — the caller renders at the export resolution,
+  // this only guards against a mismatched surface.
+  MTLSize copySize = MTLSizeMake(MIN(mlTexture.width, destination.width),
+                                 MIN(mlTexture.height, destination.height), 1);
+
   id<MTLCommandBuffer> commandBuffer = [commandQueue commandBuffer];
   id<MTLBlitCommandEncoder> blitEncoder = [commandBuffer blitCommandEncoder];
   [blitEncoder copyFromTexture:mlTexture
                    sourceSlice:0
                    sourceLevel:0
                   sourceOrigin:MTLOriginMake(0, 0, 0)
-                    sourceSize:MTLSizeMake(mlTexture.width, mlTexture.height, 1)
-                     toTexture:CVMetalTextureGetTexture(cvMetalTexture)
+                    sourceSize:copySize
+                     toTexture:destination
               destinationSlice:0
               destinationLevel:0
              destinationOrigin:MTLOriginMake(0, 0, 0)];
@@ -204,6 +213,10 @@ void VideoEncoderHostObject::encodeFrame(id<MTLTexture> mlTexture,
   // before the encoder reads the surface.
   [commandBuffer waitUntilCompleted];
   CFRelease(cvMetalTexture);
+  // Drop the cache's own reference to the surface too. Without this the cache
+  // pins every buffer it has vended a texture for, the pool can never recycle
+  // one, and a long export allocates a fresh full-resolution buffer per frame.
+  [MTLTextureUtils flushTextureCache];
 
   int attempt = 0;
   while (!assetWriterInput.isReadyForMoreMediaData) {
@@ -428,6 +441,8 @@ void VideoEncoderHostObject::release() {
     CVPixelBufferPoolRelease(pixelBufferPool);
     pixelBufferPool = NULL;
   }
+  // Release the last surfaces the cache still holds for this export.
+  [MTLTextureUtils flushTextureCache];
   commandQueue = nil;
   device = nil;
 }

--- a/ios/VideoFrame.h
+++ b/ios/VideoFrame.h
@@ -76,23 +76,42 @@ private:
 };
 
 /**
+ * Ring depth for real-time preview producers. The JS contract (see
+ * VideoFrame.texture in types.ts) is that a frame is consumed in the tick it
+ * is handed out, so the only reads that can outlive a frame's currency are
+ * GPU command buffers the preview's asynchronous flush left in flight.
+ * CAMetalLayer blocks the render loop past 3 drawables in flight, so
+ * maxDrawableCount + 1 issuances is as far as sampling can lag issuance.
+ */
+static constexpr size_t kPreviewFrameRingDepth = 4;
+
+/**
  * Bounds the lifetime of the zero-copy frames a producer (a composition item
  * decoder or the simple player) hands to JS, without depending on the JS
  * garbage collector to release them.
  *
- * Frames are retired in two stages. A frame older than `kIssuedFrameRingDepth`
- * issuances loses its texture view immediately, so no NEW sampling work can
- * reference it; its pixel buffer only goes back to the pool once the kernel
- * reports its IOSurface idle, so a buffer another subsystem still reads is
- * never recycled under it. The depth (maxDrawableCount + 1) is what actually
- * bounds how far the GPU can lag issuance, since CAMetalLayer blocks the
- * render loop past 3 drawables in flight. On the export path retiring is
- * provably safe either way: the export loop flushes synchronously
- * (surface.flush(true)), so sampling is complete before the next frame is
- * issued.
+ * Frames are retired in two stages. A frame older than `depth` issuances
+ * loses its texture view immediately, so no NEW sampling work can reference
+ * it; its pixel buffer only goes back to the pool once the kernel reports
+ * its IOSurface idle, so a buffer another subsystem still reads is never
+ * recycled under it. The in-use check cannot see command buffers Metal has
+ * merely queued, so the depth — not the check — is what actually covers
+ * in-flight GPU sampling.
  */
 class VideoFrameRing {
 public:
+  /**
+   * `depth` is how many recently issued frames stay fully alive: the
+   * consumer's sampling of a frame must provably be finished `depth`
+   * issuances after it was handed out. Preview producers use
+   * kPreviewFrameRingDepth; the sync (export) extractor uses 1, because its
+   * consumer flushes the GPU synchronously before requesting the next frame,
+   * making retirement-on-replacement safe and keeping a single decoded
+   * buffer per item instead of kPreviewFrameRingDepth of them.
+   */
+  explicit VideoFrameRing(size_t depth = kPreviewFrameRingDepth)
+      : depth(depth) {}
+
   /** Registers a freshly issued frame and runs a retirement pass. */
   void push(const std::shared_ptr<VideoFrame>& frame);
 
@@ -107,12 +126,12 @@ private:
   // Frames are issued from the render thread but a dispose can drop them from
   // the JS thread, so the lists below are guarded.
   std::mutex mutex;
+  size_t depth;
   /** Recently issued frames, kept fully alive. */
   std::list<std::shared_ptr<VideoFrame>> issuedFrames;
   /** Retired frames whose surface has not gone idle yet. */
   std::list<std::shared_ptr<VideoFrame>> retiredFrames;
 
-  static constexpr size_t kIssuedFrameRingDepth = 4;
   /**
    * Upper bound on retired frames awaiting their surface to go idle, so a
    * pathological consumer cannot pile buffers up. Force-releasing past this

--- a/ios/VideoFrame.h
+++ b/ios/VideoFrame.h
@@ -9,35 +9,12 @@
 #import <CoreVideo/CoreVideo.h>
 #import <Metal/Metal.h>
 #import <jsi/jsi.h>
+#import <list>
+#import <memory>
 #import <mutex>
 
 namespace RNSkiaVideo {
 using namespace facebook;
-
-/**
- * How many recently issued zero-copy frames a producer keeps fully alive.
- *
- * Older frames are retired in two stages: their texture view is dropped
- * immediately (no NEW sampling work can reference them), but their pixel
- * buffer only returns to the decoder pool once IOSurfaceIsInUse() reports
- * the surface free — the kernel's use count covers in-flight GPU reads, so
- * the decoder can never overwrite pixels a late command buffer still
- * samples. The depth itself (maxDrawableCount + 1) already bounds how far
- * the GPU can lag issuance, since CAMetalLayer blocks the render loop past
- * 3 drawables in flight; the use-count check turns that bound into a
- * guarantee. On the export path this is belt-and-suspenders: the export
- * loop flushes synchronously (surface.flush(true)), so sampling work is
- * provably complete before any frame becomes old enough to retire.
- */
-static constexpr size_t kIssuedFrameRingDepth = 4;
-
-/**
- * Upper bound on retired frames awaiting their surface to go idle, so a
- * pathological consumer cannot pile buffers up. Force-releasing past this
- * cap trades a bounded memory peak against a (preview-only, transient)
- * risk of sampling refreshed pixels.
- */
-static constexpr size_t kRetiredFramesHardCap = 4;
 
 /**
  * A decoded frame handed to JS. The frame OWNS its pixels: it retains the
@@ -66,9 +43,12 @@ public:
   void releaseTexture();
 
   /**
-   * Returns the pixel buffer to its pool ONLY if its IOSurface is no longer
-   * in use (the kernel's use count covers pending GPU reads), so the
-   * decoder can never overwrite pixels a late command buffer still samples.
+   * Returns the pixel buffer to its pool unless the kernel still reports its
+   * IOSurface as in use, so a buffer another subsystem is still reading is
+   * held back instead of being recycled under it. Note that the use count is
+   * a best-effort signal: it tracks explicit IOSurface users (CoreAnimation,
+   * VideoToolbox, other processes), NOT command buffers Metal has in flight,
+   * so it complements the ring depth below rather than replacing it.
    * Returns true once the buffer is gone. Idempotent.
    */
   bool tryReleaseBuffer();
@@ -93,6 +73,53 @@ private:
 
   void releaseTextureLocked();
   void releaseBufferLocked();
+};
+
+/**
+ * Bounds the lifetime of the zero-copy frames a producer (a composition item
+ * decoder or the simple player) hands to JS, without depending on the JS
+ * garbage collector to release them.
+ *
+ * Frames are retired in two stages. A frame older than `kIssuedFrameRingDepth`
+ * issuances loses its texture view immediately, so no NEW sampling work can
+ * reference it; its pixel buffer only goes back to the pool once the kernel
+ * reports its IOSurface idle, so a buffer another subsystem still reads is
+ * never recycled under it. The depth (maxDrawableCount + 1) is what actually
+ * bounds how far the GPU can lag issuance, since CAMetalLayer blocks the
+ * render loop past 3 drawables in flight. On the export path retiring is
+ * provably safe either way: the export loop flushes synchronously
+ * (surface.flush(true)), so sampling is complete before the next frame is
+ * issued.
+ */
+class VideoFrameRing {
+public:
+  /** Registers a freshly issued frame and runs a retirement pass. */
+  void push(const std::shared_ptr<VideoFrame>& frame);
+
+  /**
+   * Drops every frame the ring holds, releasing their buffers unconditionally
+   * — frames still referenced by JS turn into empty wrappers whose `texture`
+   * getter returns undefined.
+   */
+  void releaseAll();
+
+private:
+  // Frames are issued from the render thread but a dispose can drop them from
+  // the JS thread, so the lists below are guarded.
+  std::mutex mutex;
+  /** Recently issued frames, kept fully alive. */
+  std::list<std::shared_ptr<VideoFrame>> issuedFrames;
+  /** Retired frames whose surface has not gone idle yet. */
+  std::list<std::shared_ptr<VideoFrame>> retiredFrames;
+
+  static constexpr size_t kIssuedFrameRingDepth = 4;
+  /**
+   * Upper bound on retired frames awaiting their surface to go idle, so a
+   * pathological consumer cannot pile buffers up. Force-releasing past this
+   * cap trades a bounded memory peak against a (preview-only, transient)
+   * risk of sampling refreshed pixels.
+   */
+  static constexpr size_t kRetiredFramesHardCap = 4;
 };
 
 } // namespace RNSkiaVideo

--- a/ios/VideoFrame.mm
+++ b/ios/VideoFrame.mm
@@ -71,6 +71,45 @@ void VideoFrame::releaseBuffer() {
   releaseBufferLocked();
 }
 
+void VideoFrameRing::push(const std::shared_ptr<VideoFrame>& frame) {
+  std::lock_guard<std::mutex> guard(mutex);
+  issuedFrames.push_back(frame);
+  while (issuedFrames.size() > kIssuedFrameRingDepth) {
+    issuedFrames.front()->releaseTexture();
+    retiredFrames.push_back(issuedFrames.front());
+    issuedFrames.pop_front();
+  }
+  // Let go of the cache's own references to the textures we just dropped:
+  // while it holds them the surfaces stay alive whatever we do here, so
+  // their pool could never recycle them. Textures of frames still in the
+  // ring are retained by those frames and survive the flush.
+  [MTLTextureUtils flushTextureCache];
+  for (auto it = retiredFrames.begin(); it != retiredFrames.end();) {
+    if ((*it)->tryReleaseBuffer()) {
+      it = retiredFrames.erase(it);
+    } else {
+      ++it;
+    }
+  }
+  while (retiredFrames.size() > kRetiredFramesHardCap) {
+    retiredFrames.front()->releaseBuffer();
+    retiredFrames.pop_front();
+  }
+}
+
+void VideoFrameRing::releaseAll() {
+  std::lock_guard<std::mutex> guard(mutex);
+  for (const auto& frame : issuedFrames) {
+    frame->releaseBuffer();
+  }
+  issuedFrames.clear();
+  for (const auto& frame : retiredFrames) {
+    frame->releaseBuffer();
+  }
+  retiredFrames.clear();
+  [MTLTextureUtils flushTextureCache];
+}
+
 std::vector<jsi::PropNameID> VideoFrame::getPropertyNames(jsi::Runtime& rt) {
   std::vector<jsi::PropNameID> result;
   result.push_back(jsi::PropNameID::forUtf8(rt, std::string("width")));

--- a/ios/VideoFrame.mm
+++ b/ios/VideoFrame.mm
@@ -74,10 +74,15 @@ void VideoFrame::releaseBuffer() {
 void VideoFrameRing::push(const std::shared_ptr<VideoFrame>& frame) {
   std::lock_guard<std::mutex> guard(mutex);
   issuedFrames.push_back(frame);
-  while (issuedFrames.size() > kIssuedFrameRingDepth) {
+  bool retired = false;
+  while (issuedFrames.size() > depth) {
     issuedFrames.front()->releaseTexture();
     retiredFrames.push_back(issuedFrames.front());
     issuedFrames.pop_front();
+    retired = true;
+  }
+  if (!retired && retiredFrames.empty()) {
+    return;
   }
   // Let go of the cache's own references to the textures we just dropped:
   // while it holds them the surfaces stay alive whatever we do here, so

--- a/ios/VideoPlayerHostObject.h
+++ b/ios/VideoPlayerHostObject.h
@@ -3,7 +3,6 @@
 #include "RNSVEventEmitter.h"
 #include "RNSVVideoPlayer.h"
 #include "VideoFrame.h"
-#include <list>
 
 using namespace facebook;
 
@@ -35,10 +34,9 @@ private:
   RNSVVideoPlayer* player;
   RNSVSkiaVideoPlayerDelegateImpl* playerDelegate;
   std::shared_ptr<VideoFrame> currentFrame;
-  // Recently issued frames and retired frames awaiting surface idleness;
-  // lifetime never depends on the JS garbage collector (see VideoFrame.h).
-  std::list<std::shared_ptr<VideoFrame>> issuedFrames;
-  std::list<std::shared_ptr<VideoFrame>> retiredFrames;
+  // Bounds the lifetime of the frames handed to JS; never depends on the JS
+  // garbage collector (see VideoFrame.h).
+  VideoFrameRing frameRing;
   CMTime lastFrameAvailable = kCMTimeInvalid;
   CMTime lastFrameDrawn = kCMTimeInvalid;
   float width;

--- a/ios/VideoPlayerHostObject.mm
+++ b/ios/VideoPlayerHostObject.mm
@@ -67,25 +67,9 @@ jsi::Value VideoPlayerHostObject::get(jsi::Runtime& runtime,
               std::make_shared<VideoFrame>(buffer, width, height, rotation);
           CVPixelBufferRelease(buffer);
           // Deterministic lifetime (see VideoFrame.h): retire frames older
-          // than the ring, return their buffer to the pool only once the
-          // kernel reports their IOSurface idle.
-          issuedFrames.push_back(currentFrame);
-          while (issuedFrames.size() > kIssuedFrameRingDepth) {
-            issuedFrames.front()->releaseTexture();
-            retiredFrames.push_back(issuedFrames.front());
-            issuedFrames.pop_front();
-          }
-          for (auto it = retiredFrames.begin(); it != retiredFrames.end();) {
-            if ((*it)->tryReleaseBuffer()) {
-              it = retiredFrames.erase(it);
-            } else {
-              ++it;
-            }
-          }
-          while (retiredFrames.size() > kRetiredFramesHardCap) {
-            retiredFrames.front()->releaseBuffer();
-            retiredFrames.pop_front();
-          }
+          // than the ring and give their buffer back to the player's pool as
+          // soon as nothing reads it anymore.
+          frameRing.push(currentFrame);
           return jsi::Object::createFromHostObject(runtime, currentFrame);
         });
   } else if (propName == "play") {
@@ -219,14 +203,7 @@ void VideoPlayerHostObject::readyToPlay(float width, float height,
 void VideoPlayerHostObject::release() {
   if (!released.test_and_set()) {
     removeAllListeners();
-    for (const auto& frame : issuedFrames) {
-      frame->releaseBuffer();
-    }
-    issuedFrames.clear();
-    for (const auto& frame : retiredFrames) {
-      frame->releaseBuffer();
-    }
-    retiredFrames.clear();
+    frameRing.releaseAll();
     if (currentFrame) {
       currentFrame = nullptr;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,10 +4,20 @@ import type { SkCanvas, SkSurface, Skia } from '@shopify/react-native-skia';
 
 /**
  * Represents a video frame.
+ *
+ * Frames are transient: draw a frame in the tick it is handed to you. The
+ * native side owns the frame's pixels and reclaims them once the frame has
+ * been superseded by later decode calls, so a retained frame's `texture`
+ * eventually becomes undefined — retaining a frame never leaks memory, but
+ * it is not a way to keep its pixels either.
  */
 export type VideoFrame = {
   /**
    * The native texture of the frame.
+   *
+   * Only valid until further frames have been decoded by the producing
+   * player or extractor; undefined once the frame's pixels have been
+   * reclaimed.
    */
   texture: unknown;
   /**
@@ -329,6 +339,10 @@ export type VideoCompositionFramesExtractorSync = {
   /**
    * Decodes the frames until reaching the specified time.
    * This method will block the current thread until the frames are decoded.
+   *
+   * The returned frames are only valid until the next call: draw them and
+   * flush the GPU synchronously (`surface.flush(true)`) before decoding
+   * further frames.
    *
    * @returns The decoded video frames of the composition items.
    */


### PR DESCRIPTION
The zero-copy path never flushed the CVMetalTextureCache. The cache keeps its own reference to every IOSurface it vends a texture for, so on the encode side no pooled buffer could ever be recycled: each frame allocated a fresh full-resolution buffer and a long export grew without bound. On the decode side the same reference kept a retired frame's surface alive, so IOSurfaceIsInUse() could never report it idle and the ring degraded into force-releasing at its hard cap. Both paths now flush once the frame is done with, which is what CoreVideo asks of a cache client anyway.

The eviction ring was duplicated verbatim between the composition decoder and the simple player; it moves to a VideoFrameRing owning the flush ordering (drop our texture, flush the cache, then test the surface), and guards its lists — frames are issued from the render thread but a dispose drops them from the JS thread.

Also: serialize texture-cache access, since it is now reached from the decoder queues, the render thread and the export thread and CoreVideo makes no thread-safety promise; share one MTLDevice between the cache and the encoder's command queue, as Metal cannot blit across devices; crop the encode blit to the destination rather than fault the GPU on a mismatched surface; and ask the simple player's output for IOSurface backing explicitly, which the recycling check now depends on.


Claude-Session: https://claude.ai/code/session_01QbX44LtRT45CNftHrtUs5K