### PR TITLE
fix(player): dispose the offscreen surface and re-key it on size

### DIFF
--- a/src/videoCompositionPlayer.ts
+++ b/src/videoCompositionPlayer.ts
@@ -155,21 +155,56 @@ export const useVideoCompositionPlayer = ({
   }, [framesExtractor, autoPlay]);
 
   const surfaceSharedValue = useSharedValue<SkSurface | null>(null);
+  const surfaceWidth = useSharedValue(0);
+  const surfaceHeight = useSharedValue(0);
   const pixelRatio = PixelRatio.get();
+
+  // Release the offscreen surface with the hook that made it. Without this a
+  // caller that mounts and unmounts the player repeatedly — a player inside a
+  // modal, say — leaks a full size texture per cycle. runOnUI because this
+  // effect is declared before the frame callback below, and so its cleanup runs
+  // before the callback is unregistered.
+  useEffect(
+    () => () => {
+      runOnUI(() => {
+        surfaceSharedValue.value?.dispose();
+        surfaceSharedValue.value = null;
+        surfaceWidth.value = 0;
+        surfaceHeight.value = 0;
+      })();
+    },
+    [surfaceSharedValue, surfaceWidth, surfaceHeight]
+  );
+
   useFrameCallback(() => {
     'worklet';
     if (!framesExtractor) {
       return;
     }
 
+    const pixelWidth = width * pixelRatio;
+    const pixelHeight = height * pixelRatio;
+
     let surface: SkSurface | null = surfaceSharedValue.value;
 
-    if (!surface) {
-      surface = Skia.Surface.MakeOffscreen(
-        width * pixelRatio,
-        height * pixelRatio
-      );
+    if (
+      !surface ||
+      surfaceWidth.value !== pixelWidth ||
+      surfaceHeight.value !== pixelHeight
+    ) {
+      // width and height can change while the player stays mounted — laying the
+      // stage out for a different aspect ratio calls the hook with new
+      // dimensions and the same surface. Drawing the new size into the old
+      // texture and then declaring the result to be the new size stretches the
+      // picture by the ratio between them, so the surface is re-keyed on its
+      // dimensions the way exportVideoComposition already re-keys its own.
+      surface?.dispose();
+      surface = Skia.Surface.MakeOffscreen(pixelWidth, pixelHeight);
       surfaceSharedValue.value = surface;
+      surfaceWidth.value = pixelWidth;
+      surfaceHeight.value = pixelHeight;
+      // The recycled wrapper below is bound to the texture that just went away.
+      currentFrame.value = null;
     }
     if (!surface) {
       console.warn('Failed to create surface');
@@ -184,8 +219,8 @@ export const useVideoCompositionPlayer = ({
       videoComposition: composition!,
       currentTime: framesExtractor.currentTime,
       frames: framesExtractor.decodeCompositionFrames(),
-      width: width * pixelRatio,
-      height: height * pixelRatio,
+      width: pixelWidth,
+      height: pixelHeight,
     });
     surface.flush();
     const previousFrame = currentFrame.value;
@@ -194,8 +229,8 @@ export const useVideoCompositionPlayer = ({
       // JSI object on every frame.
       const nextFrame = Skia.Image.MakeImageFromNativeTextureUnstable(
         surface.getNativeTextureUnstable(),
-        width * pixelRatio,
-        height * pixelRatio,
+        pixelWidth,
+        pixelHeight,
         false,
         previousFrame ?? undefined
       );


### PR DESCRIPTION
## Summary

`useVideoCompositionPlayer` creates its offscreen surface lazily inside the frame callback, then holds onto it for the life of the hook:

```ts
let surface: SkSurface | null = surfaceSharedValue.value;

if (!surface) {
  surface = Skia.Surface.MakeOffscreen(width * pixelRatio, height * pixelRatio);
  surfaceSharedValue.value = surface;
}
```

Two bugs follow from those four lines, and this PR fixes both.

## 1. The surface is never disposed

Nothing releases it. The hook already has a cleanup effect, but it only covers the frames extractor and the current frame:

```ts
useEffect(
  () => () => {
    currentFrame.value = null;
    framesExtractor?.dispose();
  },
  [currentFrame, framesExtractor]
);
```

The surface is created in the frame callback, not in an effect, so it falls outside that cleanup and outlives the hook. Every mount allocates a full size GPU texture; every unmount drops the only reference to it without calling `dispose()`. A player that mounts and unmounts repeatedly — one living inside a modal, for instance — leaks one texture per cycle. At 1080p that is roughly 8 MB of GPU memory each time.

**Fix:** a cleanup effect that disposes the surface and clears the shared values.

Two details in that effect are deliberate:

- It runs through `runOnUI` because the surface is owned by the UI runtime — it is created and used inside a worklet, and disposing it from the JS thread would cross runtimes.
- It is declared **before** `useFrameCallback`. React runs cleanup functions in declaration order, so this one runs while the frame callback is still registered rather than after it has been torn down. Placing it after would invert that order.

## 2. The surface is not re-created when the size changes

The guard is `if (!surface)` — it asks whether a surface exists, never whether it still matches the requested size.

`width` and `height` are ordinary props, and nothing stops them from changing while the player stays mounted; laying the stage out for a different aspect ratio does exactly that. When they change, the branch is skipped because the surface is non-null, so the frame is drawn at the new dimensions into a texture allocated for the old ones. The result is then wrapped as an image of the *new* size:

```ts
Skia.Image.MakeImageFromNativeTextureUnstable(
  surface.getNativeTextureUnstable(),
  width * pixelRatio,   // the new size…
  height * pixelRatio,  // …over a texture allocated for the old one
  ...
)
```

The texture keeps its original dimensions while the wrapper claims the new ones, so the picture is stretched by the ratio between the two. It stays wrong until the player is remounted, since nothing else ever invalidates the surface.

**Fix:** track the dimensions the surface was made at in two shared values, and re-key the surface whenever they no longer match — disposing the old one before replacing it.

This is not a new pattern in this codebase. `exportVideoComposition` already caches its surface exactly this way, comparing against `__rnskvExportSurfaceWidth` / `__rnskvExportSurfaceHeight` before reusing it (`src/exportVideoComposition.ts`). The export path was already correct; this brings the player in line with it.

## Why `currentFrame` is cleared when the surface is replaced

Worth calling out, because it is the non-obvious part of the change.

The frame path recycles the previous `SkImage` wrapper to avoid allocating a JSI object on every frame, passing it back as the last argument:

```ts
Skia.Image.MakeImageFromNativeTextureUnstable(..., previousFrame ?? undefined)
```

That wrapper is bound to the texture it was created from. When the surface is disposed and replaced, the wrapper still points at the texture that just went away, so handing it back as the recycling target would reuse a dead one. Setting `currentFrame.value = null` at that moment forces the next frame to allocate a fresh wrapper; recycling resumes normally from there.

## Incidental cleanup

`width * pixelRatio` and `height * pixelRatio` were computed independently in three places — the surface allocation, the `drawFrame` call and the image wrapper. They are now hoisted into `pixelWidth` / `pixelHeight` at the top of the callback, so the three cannot drift apart. This is what made bug 2 possible to write in the first place: the allocation used one pair of values and the wrapper another, with nothing tying them together.

## Scope and risk

One file, `src/videoCompositionPlayer.ts`. No API change, no behavioural change for callers whose dimensions are constant — for them the size comparison always matches and the surface is created exactly once, as before. No new imports: `useEffect` and `runOnUI` were already imported in this file.

`lib/` is build output and is not touched.

## Testing

`yarn typecheck` and `yarn lint` both pass clean.
